### PR TITLE
Add location field to virtual guest object

### DIFF
--- a/data_types/softlayer_virtual_guest.go
+++ b/data_types/softlayer_virtual_guest.go
@@ -34,6 +34,8 @@ type SoftLayer_Virtual_Guest struct {
 	ManagedResourceFlag     bool   `json:"managedResourceFlag,omitempty"`
 	PrimaryBackendIpAddress string `json:"primaryBackendIpAddress,omitempty"`
 	PrimaryIpAddress        string `json:"primaryIpAddress,omitempty"`
+
+	Location *SoftLayer_Location `json:"location"`
 }
 
 type SoftLayer_Virtual_Guest_Template_Parameters struct {

--- a/services/softlayer_virtual_guest.go
+++ b/services/softlayer_virtual_guest.go
@@ -62,7 +62,38 @@ func (slvgs *softLayer_Virtual_Guest_Service) CreateObject(template datatypes.So
 }
 
 func (slvgs *softLayer_Virtual_Guest_Service) GetObject(instanceId int) (datatypes.SoftLayer_Virtual_Guest, error) {
-	response, err := slvgs.client.DoRawHttpRequest(fmt.Sprintf("%s/%d/getObject.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+
+	objectMask := []string{
+		"accountId",
+		"createDate",
+		"dedicatedAccountHostOnlyFlag",
+		"domain",
+		"fullyQualifiedDomainName",
+		"hostname",
+		"id",
+		"lastPowerStateId",
+		"lastVerifiedDate",
+		"maxCpu",
+		"maxCpuUnits",
+		"maxMemory",
+		"metricPollDate",
+		"modifyDate",
+		"notes",
+		"postInstallScriptUri",
+		"privateNetworkOnlyFlag",
+		"startCpus",
+		"statusId",
+		"uuid",
+
+		"globalIdentifier",
+		"managedResourceFlag",
+		"primaryBackendIpAddress",
+		"primaryIpAddress",
+
+		"location.id",
+	}
+
+	response, err := slvgs.client.DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getObject.json", slvgs.GetName(), instanceId), objectMask, "GET", new(bytes.Buffer))
 	if err != nil {
 		return datatypes.SoftLayer_Virtual_Guest{}, err
 	}

--- a/services/softlayer_virtual_guest_test.go
+++ b/services/softlayer_virtual_guest_test.go
@@ -121,6 +121,7 @@ var _ = Describe("SoftLayer_Virtual_Guest_Service", func() {
 			Expect(vg.GlobalIdentifier).To(Equal("52145e01-97b6-4312-9c15-dac7f24b6c2a"))
 			Expect(vg.PrimaryBackendIpAddress).To(Equal("10.106.192.42"))
 			Expect(vg.PrimaryIpAddress).To(Equal("23.246.234.32"))
+			Expect(vg.Location.Id).To(Equal(1234567))
 		})
 	})
 

--- a/test_fixtures/services/SoftLayer_Virtual_Guest_Service_getObject.json
+++ b/test_fixtures/services/SoftLayer_Virtual_Guest_Service_getObject.json
@@ -18,5 +18,8 @@
 	"uuid": "85d444ce-55a0-39c0-e17a-f697f223cd8a",
 	"globalIdentifier": "52145e01-97b6-4312-9c15-dac7f24b6c2a",
 	"primaryBackendIpAddress": "10.106.192.42",
-	"primaryIpAddress": "23.246.234.32"
+	"primaryIpAddress": "23.246.234.32",
+	"location": {
+		"id": 1234567
+	}
 }


### PR DESCRIPTION
Add location field to the virtual guest object so that cpi can use this field to decide where to create remote iscsi disks

Signed-off-by: Edward Zhang zhuadl@cn.ibm.com
