### PR TITLE
Add a new method "AttachEphemeralDisk" for virtual guest

### DIFF
--- a/data_types/softlayer_item_price.go
+++ b/data_types/softlayer_item_price.go
@@ -1,12 +1,17 @@
 package data_types
 
 type SoftLayer_Item_Price struct {
-	Id   int   `json:"id"`
-	Item *Item `json:"item"`
+	Id         int        `json:"id"`
+	Categories []Category `json:"categories,omitempty"`
+	Item       *Item      `json:"item,omitempty"`
 }
 
 type Item struct {
 	Id          int    `json:"id"`
 	Description string `json:"description"`
 	Capacity    string `json:"capacity"`
+}
+
+type Category struct {
+	CategoryCode string `json:"categoryCode"`
 }

--- a/data_types/softlayer_product_order.go
+++ b/data_types/softlayer_product_order.go
@@ -9,8 +9,19 @@ type SoftLayer_Product_Order_Parameters struct {
 }
 
 type SoftLayer_Product_Order struct {
-	ComplexType string                 `json:"complexType"`
-	Location    string                 `json:"location"`
-	PackageId   int                    `json:"packageId"`
-	Prices      []SoftLayer_Item_Price `json:"prices"`
+	ComplexType   string                 `json:"complexType"`
+	Location      string                 `json:"location,omitempty"`
+	PackageId     int                    `json:"packageId,omitempty"`
+	Prices        []SoftLayer_Item_Price `json:"prices,omitempty"`
+	VirtualGuests []VirtualGuest         `json:"virtualGuests,omitempty"`
+	Properties    []Property             `json:"properties,omitempty"`
+}
+
+type Property struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type VirtualGuest struct {
+	Id int `json:"id"`
 }

--- a/services/softlayer_virtual_guest_test.go
+++ b/services/softlayer_virtual_guest_test.go
@@ -166,6 +166,18 @@ var _ = Describe("SoftLayer_Virtual_Guest_Service", func() {
 		})
 	})
 
+	Context("#AttachEphemeralDisk", func() {
+		BeforeEach(func() {
+			fakeClient.DoRawHttpRequestResponse, err = common.ReadJsonTestFixtures("services", "SoftLayer_Product_Order_placeOrder.json")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("can attach a local disk without error", func() {
+			err := virtualGuestService.AttachEphemeralDisk(123, 25)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	Context("#GetPowerState", func() {
 		BeforeEach(func() {
 			virtualGuest.Id = 1234567

--- a/softlayer/softlayer_virtual_guest_service.go
+++ b/softlayer/softlayer_virtual_guest_service.go
@@ -40,4 +40,6 @@ type SoftLayer_Virtual_Guest_Service interface {
 
 	AttachIscsiVolume(instanceId int, volumeId int) (string, error)
 	DetachIscsiVolume(instanceId int, volumeId int) error
+
+	AttachEphemeralDisk(instanceId int, diskSize int) error
 }


### PR DESCRIPTION
this method is used for attach a second local disk to the virtual guest.

Signed-off-by: Edward Zhang <zhuadl@cn.ibm.com>