### PR TITLE
Add one new service "GetUpgradeItemPrices" for virtual guest

### DIFF
--- a/services/softlayer_virtual_guest.go
+++ b/services/softlayer_virtual_guest.go
@@ -445,6 +445,21 @@ func (slvgs *softLayer_Virtual_Guest_Service) AttachEphemeralDisk(instanceId int
 	return err
 }
 
+func (slvgs *softLayer_Virtual_Guest_Service) GetUpgradeItemPrices(instanceId int) ([]datatypes.SoftLayer_Item_Price, error) {
+	response, err := slvgs.client.DoRawHttpRequest(fmt.Sprintf("%s/%d/getUpgradeItemPrices.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Item_Price{}, err
+	}
+
+	itemPrices := []datatypes.SoftLayer_Item_Price{}
+	err = json.Unmarshal(response, &itemPrices)
+	if err != nil {
+		return []datatypes.SoftLayer_Item_Price{}, err
+	}
+
+	return itemPrices, nil
+}
+
 //Private methods
 
 func (slvgs *softLayer_Virtual_Guest_Service) attachVolumeBasedOnShellScript(virtualGuest datatypes.SoftLayer_Virtual_Guest, volume datatypes.SoftLayer_Network_Storage) (string, error) {

--- a/services/softlayer_virtual_guest.go
+++ b/services/softlayer_virtual_guest.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,7 +16,8 @@ import (
 )
 
 const (
-	ROOT_USER_NAME = "root"
+	ROOT_USER_NAME               = "root"
+	EPHEMERAL_DISK_CATEGORY_CODE = "guest_disk1"
 )
 
 type softLayer_Virtual_Guest_Service struct {
@@ -406,6 +408,11 @@ func (slvgs *softLayer_Virtual_Guest_Service) IsPingable(instanceId int) (bool, 
 }
 
 func (slvgs *softLayer_Virtual_Guest_Service) AttachEphemeralDisk(instanceId int, diskSize int) error {
+	diskItemPrice, err := slvgs.findUpgradeItemPriceForEphemeralDisk(instanceId, diskSize)
+	if err != nil {
+		return err
+	}
+
 	service, err := slvgs.client.GetSoftLayer_Product_Order_Service()
 	if err != nil {
 		return err
@@ -419,10 +426,10 @@ func (slvgs *softLayer_Virtual_Guest_Service) AttachEphemeralDisk(instanceId int
 		},
 		Prices: []datatypes.SoftLayer_Item_Price{
 			datatypes.SoftLayer_Item_Price{
-				Id: 29190, // ToDO: now we just attach a 25G local disk, need to query local disk size according to the diskSize parameter
+				Id: diskItemPrice.Id,
 				Categories: []datatypes.Category{
 					datatypes.Category{
-						CategoryCode: "guest_disk1",
+						CategoryCode: EPHEMERAL_DISK_CATEGORY_CODE,
 					},
 				},
 			},
@@ -431,7 +438,7 @@ func (slvgs *softLayer_Virtual_Guest_Service) AttachEphemeralDisk(instanceId int
 		Properties: []datatypes.Property{
 			datatypes.Property{
 				Name:  "MAINTENANCE_WINDOW",
-				Value: time.Now().UTC().Format(time.RFC3339Nano),
+				Value: time.Now().UTC().Format(time.RFC3339),
 			},
 			datatypes.Property{
 				Name:  "NOTE_GENERAL",
@@ -592,4 +599,47 @@ func (slvgs *softLayer_Virtual_Guest_Service) getRootPassword(virtualGuest datat
 	}
 
 	return ""
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) findUpgradeItemPriceForEphemeralDisk(instanceId int, ephemeralDiskSize int) (datatypes.SoftLayer_Item_Price, error) {
+	if ephemeralDiskSize <= 0 {
+		return datatypes.SoftLayer_Item_Price{}, errors.New(fmt.Sprintf("Ephemeral disk size can not be negative: %d", ephemeralDiskSize))
+	}
+
+	itemPrices, err := slvgs.GetUpgradeItemPrices(instanceId)
+	if err != nil {
+		return datatypes.SoftLayer_Item_Price{}, nil
+	}
+
+	var currentDiskCapacity int
+	var currentItemPrice datatypes.SoftLayer_Item_Price
+
+	for _, itemPrice := range itemPrices {
+
+		flag := false
+		for _, category := range itemPrice.Categories {
+			if category.CategoryCode == EPHEMERAL_DISK_CATEGORY_CODE {
+				flag = true
+				break
+			}
+		}
+
+		if flag && strings.Contains(itemPrice.Item.Description, "(LOCAL)") {
+
+			capacity, _ := strconv.Atoi(itemPrice.Item.Capacity)
+
+			if capacity >= ephemeralDiskSize {
+				if currentItemPrice.Id == 0 || currentDiskCapacity >= capacity {
+					currentItemPrice = itemPrice
+					currentDiskCapacity = capacity
+				}
+			}
+		}
+	}
+
+	if currentItemPrice.Id == 0 {
+		return datatypes.SoftLayer_Item_Price{}, errors.New(fmt.Sprintf("No proper local disk for size %d", ephemeralDiskSize))
+	}
+
+	return currentItemPrice, nil
 }

--- a/services/softlayer_virtual_guest_test.go
+++ b/services/softlayer_virtual_guest_test.go
@@ -172,10 +172,24 @@ var _ = Describe("SoftLayer_Virtual_Guest_Service", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("reports error when providing a wrong disk size", func() {
+			err := virtualGuestService.AttachEphemeralDisk(123, -1)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Ephemeral disk size can not be negative: -1"))
+		})
+
 		It("can attach a local disk without error", func() {
 			err := virtualGuestService.AttachEphemeralDisk(123, 25)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("reports error when providing a disk size that exceeds the biggest capacity disk SL can provide", func() {
+			fakeClient.DoRawHttpRequestResponse, err = common.ReadJsonTestFixtures("services", "SoftLayer_Virtual_Guest_Service_getUpgradeItemPrices.json")
+			err := virtualGuestService.AttachEphemeralDisk(123, 26)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("No proper local disk for size 26"))
+		})
+
 	})
 
 	Context("#GetPowerState", func() {

--- a/services/softlayer_virtual_guest_test.go
+++ b/services/softlayer_virtual_guest_test.go
@@ -532,4 +532,22 @@ var _ = Describe("SoftLayer_Virtual_Guest_Service", func() {
 			Expect(transaction.TransactionStatus.Name).To(Equal("CLOUD_CONFIGURE_METADATA_DISK"))
 		})
 	})
+
+	Context("#GetUpgradeItemPrices", func() {
+		BeforeEach(func() {
+			virtualGuest.Id = 1234567
+			fakeClient.DoRawHttpRequestResponse, err = common.ReadJsonTestFixtures("services", "SoftLayer_Virtual_Guest_Service_getUpgradeItemPrices.json")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("sucessfully get the upgrade item prices for a virtual guest", func() {
+			itemPrices, err := virtualGuestService.GetUpgradeItemPrices(virtualGuest.Id)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(len(itemPrices)).To(Equal(1))
+			Expect(itemPrices[0].Id).To(Equal(12345))
+			Expect(itemPrices[0].Categories[0].CategoryCode).To(Equal("guest_disk1"))
+		})
+	})
+
 })

--- a/softlayer/softlayer_virtual_guest_service.go
+++ b/softlayer/softlayer_virtual_guest_service.go
@@ -42,4 +42,6 @@ type SoftLayer_Virtual_Guest_Service interface {
 	DetachIscsiVolume(instanceId int, volumeId int) error
 
 	AttachEphemeralDisk(instanceId int, diskSize int) error
+
+	GetUpgradeItemPrices(instanceId int) ([]datatypes.SoftLayer_Item_Price, error)
 }

--- a/test_fixtures/services/SoftLayer_Virtual_Guest_Service_getUpgradeItemPrices.json
+++ b/test_fixtures/services/SoftLayer_Virtual_Guest_Service_getUpgradeItemPrices.json
@@ -1,0 +1,46 @@
+[
+	{
+        "currentPriceFlag": false,
+        "hourlyRecurringFee": ".001",
+        "id": 12345,
+        "itemId": 1,
+        "laborFee": "0",
+        "onSaleFlag": null,
+        "oneTimeFee": "0",
+        "quantity": null,
+        "recurringFee": "0.01",
+        "setupFee": "0",
+        "sort": 0,
+        "accountRestrictions": [],
+        "categories": [
+            {
+                "categoryCode": "guest_disk1",
+                "id": 1,
+                "name": "fake-category",
+                "quantityLimit": 0
+            }
+        ],
+        "item": {
+            "capacity": "25",
+            "description": "25 GB (LOCAL)",
+            "id": 1,
+            "itemTaxCategoryId": 1,
+            "keyName": "fake-key-name",
+            "softwareDescriptionId": null,
+            "units": "GB",
+            "upgradeItemId": null,
+            "attributes": [
+                {
+                    "id": 1,
+                    "itemAttributeTypeId": 1,
+                    "itemId": 1,
+                    "value": "1",
+                    "attributeType": {
+                        "keyName": "fake-key",
+                        "name": "fake-name"
+                    }
+                }
+            ]
+        }
+    }
+]


### PR DESCRIPTION
This service will help to find the upgrade item prices for a single virtual guest, which can be used to
retrieve the attachable ephemeral disk item id for the virtual guest.

Signed-off-by: Edward Zhang <zhuadl@cn.ibm.com>