### PR TITLE
Fix some datatypes to help create persistent iSCSI disk

### DIFF
--- a/data_types/softlayer_product_order.go
+++ b/data_types/softlayer_product_order.go
@@ -11,7 +11,7 @@ type SoftLayer_Product_Order_Parameters struct {
 type SoftLayer_Product_Order struct {
 	ComplexType   string                 `json:"complexType"`
 	Location      string                 `json:"location,omitempty"`
-	PackageId     int                    `json:"packageId,omitempty"`
+	PackageId     int                    `json:"packageId"`
 	Prices        []SoftLayer_Item_Price `json:"prices,omitempty"`
 	VirtualGuests []VirtualGuest         `json:"virtualGuests,omitempty"`
 	Properties    []Property             `json:"properties,omitempty"`

--- a/data_types/softlayer_virtual_guest.go
+++ b/data_types/softlayer_virtual_guest.go
@@ -35,7 +35,8 @@ type SoftLayer_Virtual_Guest struct {
 	PrimaryBackendIpAddress string `json:"primaryBackendIpAddress,omitempty"`
 	PrimaryIpAddress        string `json:"primaryIpAddress,omitempty"`
 
-	Location *SoftLayer_Location `json:"location"`
+	Location   *SoftLayer_Location `json:"location"`
+	Datacenter *SoftLayer_Location `json:"datacenter"`
 
 	OperatingSystem *SoftLayer_Operating_System `json:"operatingSystem"`
 }

--- a/services/softlayer_virtual_guest.go
+++ b/services/softlayer_virtual_guest.go
@@ -100,6 +100,7 @@ func (slvgs *softLayer_Virtual_Guest_Service) GetObject(instanceId int) (datatyp
 		"primaryIpAddress",
 
 		"location.id",
+		"datacenter.id",
 		"operatingSystem.passwords.password",
 		"operatingSystem.passwords.username",
 	}


### PR DESCRIPTION
Fixed two datatypes to help create persistent iSCSI disk:
(1). remove the packageID 'omitempty' tag from the placeOrder datatype, as in iSCSI disk creation process, the packageId is 0 and SL need this packageId parameter in the placeOrder request.

(2). add datacenter attribute in the virtual guest datatype, as in the CPI, we need to get the datacenter id of the virtual guest to create an iSCSI disk.

These changes will not affect ephmeral disk feature, which we have tested.

Signed-off-by: Edward Zhang <zhuadl@cn.ibm.com>