### PR TITLE
Refactor the ssh client code

### DIFF
--- a/client/fakes/softlayer_client_fake.go
+++ b/client/fakes/softlayer_client_fake.go
@@ -22,6 +22,8 @@ type FakeSoftLayerClient struct {
 
 	TemplatePath string
 
+	ExecShellCommandResult string
+
 	SoftLayerServices map[string]softlayer.Service
 
 	DoRawHttpRequestResponse       []byte
@@ -32,7 +34,7 @@ type FakeSoftLayerClient struct {
 	GenerateRequestBodyBuffer *bytes.Buffer
 	GenerateRequestBodyError  error
 
-	HasErrorsError, CheckForHttpResponseError error
+	HasErrorsError, CheckForHttpResponseError, ExecShellCommandError error
 }
 
 func NewFakeSoftLayerClient(username, apiKey string) *FakeSoftLayerClient {
@@ -200,6 +202,10 @@ func (fslc *FakeSoftLayerClient) HasErrors(body map[string]interface{}) error {
 
 func (fslc *FakeSoftLayerClient) CheckForHttpResponseErrors(data []byte) error {
 	return fslc.CheckForHttpResponseError
+}
+
+func (fslc *FakeSoftLayerClient) ExecShellCommand(username string, password string, ip string, command string) (string, error) {
+	return fslc.ExecShellCommandResult, fslc.ExecShellCommandError
 }
 
 //Private methods

--- a/client/softlayer_client.go
+++ b/client/softlayer_client.go
@@ -260,3 +260,13 @@ func (slc *softLayerClient) makeHttpRequest(url string, requestType string, requ
 
 	return responseBody, nil
 }
+
+func (slc *softLayerClient) ExecShellCommand(username string, password string, ip string, command string) (string, error) {
+	sshClient, err := getSshClient(username, password, ip)
+	if err != nil {
+		return "", err
+	}
+	defer sshClient.Close()
+
+	return sshClient.ExecCommand(command)
+}

--- a/client/ssh_client.go
+++ b/client/ssh_client.go
@@ -1,4 +1,4 @@
-package utils
+package client
 
 import (
 	"code.google.com/p/go.crypto/ssh"
@@ -13,7 +13,7 @@ type softlayerSshClient struct {
 	client *ssh.Client
 }
 
-func GetSshClient(username string, password string, ip string) (*softlayerSshClient, error) {
+func getSshClient(username string, password string, ip string) (*softlayerSshClient, error) {
 	config := &ssh.ClientConfig{
 		User: username,
 		Auth: []ssh.AuthMethod{

--- a/softlayer/client.go
+++ b/softlayer/client.go
@@ -24,4 +24,5 @@ type Client interface {
 	HasErrors(body map[string]interface{}) error
 
 	CheckForHttpResponseErrors(data []byte) error
+	ExecShellCommand(username string, password string, ip string, command string) (string, error)
 }


### PR DESCRIPTION
We found out that during the softlayer-go attach/detach iSCSI volumes, the API will call ssh to execute some iSCSI scripts. This invocation process will cause some trouble in writing test cases for attach/detach persistent disk in bosh-softlayer-cpi project.

As a result, we refactor the shell script execution code process and move ssh client code to client package. After this code refactor, the shell script call from attach/detach API will be delegated to softlayer client, and the softlayer client will use the ssh client to finish the script execution.

After this change, now CPI project can use a fake ssh client which is inside the fake softlayer client in the test cases.

Signed-off-by: Tom Xing <xingzhou@cn.ibm.com>