### PR TITLE
Create consistent performance iscsi disk support

### DIFF
--- a/client/fakes/softlayer_client_fake.go
+++ b/client/fakes/softlayer_client_fake.go
@@ -183,6 +183,21 @@ func (fslc *FakeSoftLayerClient) DoRawHttpRequestWithObjectMask(path string, mas
 	}
 }
 
+func (fslc *FakeSoftLayerClient) DoRawHttpRequestWithObjectFilterAndObjectMask(path string, masks []string, filters string, requestType string, requestBody *bytes.Buffer) ([]byte, error) {
+	fslc.DoRawHttpRequestResponseCount += 1
+
+	if fslc.DoRawHttpRequestError != nil {
+		return []byte{}, fslc.DoRawHttpRequestError
+	}
+
+	if fslc.DoRawHttpRequestResponse != nil {
+		return fslc.DoRawHttpRequestResponse, fslc.DoRawHttpRequestError
+	} else {
+		fslc.DoRawHttpRequestResponsesIndex = fslc.DoRawHttpRequestResponsesIndex + 1
+		return fslc.DoRawHttpRequestResponses[fslc.DoRawHttpRequestResponsesIndex-1], fslc.DoRawHttpRequestError
+	}
+}
+
 func (fslc *FakeSoftLayerClient) DoRawHttpRequest(path string, requestType string, requestBody *bytes.Buffer) ([]byte, error) {
 	fslc.DoRawHttpRequestResponseCount += 1
 

--- a/client/softlayer_client.go
+++ b/client/softlayer_client.go
@@ -188,7 +188,7 @@ func (slc *softLayerClient) DoRawHttpRequestWithObjectFilterAndObjectMask(path s
 			url += ";"
 		}
 	}
-	url +="]"
+	url += "]"
 
 	return slc.makeHttpRequest(url, requestType, requestBody)
 }

--- a/client/softlayer_client.go
+++ b/client/softlayer_client.go
@@ -176,6 +176,23 @@ func (slc *softLayerClient) DoRawHttpRequestWithObjectMask(path string, masks []
 	return slc.makeHttpRequest(url, requestType, requestBody)
 }
 
+func (slc *softLayerClient) DoRawHttpRequestWithObjectFilterAndObjectMask(path string, masks []string, filters string, requestType string, requestBody *bytes.Buffer) ([]byte, error) {
+	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.apiKey, SOFTLAYER_API_URL, path)
+
+	url += "?objectFilter=" + filters
+
+	url += "&objectMask=filteredMask["
+	for i := 0; i < len(masks); i++ {
+		url += masks[i]
+		if i != len(masks)-1 {
+			url += ";"
+		}
+	}
+	url +="]"
+
+	return slc.makeHttpRequest(url, requestType, requestBody)
+}
+
 func (slc *softLayerClient) DoRawHttpRequest(path string, requestType string, requestBody *bytes.Buffer) ([]byte, error) {
 	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.apiKey, SOFTLAYER_API_URL, path)
 	return slc.makeHttpRequest(url, requestType, requestBody)

--- a/data_types/softlayer_item_price.go
+++ b/data_types/softlayer_item_price.go
@@ -1,10 +1,10 @@
 package data_types
 
 type SoftLayer_Item_Price struct {
-	Id         int        `json:"id"`
-	LocationGroupId		int   	   `json:"locationGroupId"`
-	Categories []Category `json:"categories,omitempty"`
-	Item       *Item      `json:"item,omitempty"`
+	Id              int        `json:"id"`
+	LocationGroupId int        `json:"locationGroupId"`
+	Categories      []Category `json:"categories,omitempty"`
+	Item            *Item      `json:"item,omitempty"`
 }
 
 type Item struct {

--- a/data_types/softlayer_item_price.go
+++ b/data_types/softlayer_item_price.go
@@ -2,6 +2,7 @@ package data_types
 
 type SoftLayer_Item_Price struct {
 	Id         int        `json:"id"`
+	LocationGroupId		int   	   `json:"locationGroupId"`
 	Categories []Category `json:"categories,omitempty"`
 	Item       *Item      `json:"item,omitempty"`
 }

--- a/data_types/softlayer_product_order.go
+++ b/data_types/softlayer_product_order.go
@@ -15,6 +15,13 @@ type SoftLayer_Product_Order struct {
 	Prices        []SoftLayer_Item_Price `json:"prices,omitempty"`
 	VirtualGuests []VirtualGuest         `json:"virtualGuests,omitempty"`
 	Properties    []Property             `json:"properties,omitempty"`
+	OsFormatType  OsFormatType           `json:"osFormatType,omitempty"`
+	Quantity      int 					 `json:"quantity,omitempty"`
+}
+
+type OsFormatType struct {
+	Id int `json:"id"`
+	KeyName string  `json:"keyName"`
 }
 
 type Property struct {

--- a/data_types/softlayer_product_order.go
+++ b/data_types/softlayer_product_order.go
@@ -16,12 +16,12 @@ type SoftLayer_Product_Order struct {
 	VirtualGuests []VirtualGuest         `json:"virtualGuests,omitempty"`
 	Properties    []Property             `json:"properties,omitempty"`
 	OsFormatType  OsFormatType           `json:"osFormatType,omitempty"`
-	Quantity      int 					 `json:"quantity,omitempty"`
+	Quantity      int                    `json:"quantity,omitempty"`
 }
 
 type OsFormatType struct {
-	Id int `json:"id"`
-	KeyName string  `json:"keyName"`
+	Id      int    `json:"id"`
+	KeyName string `json:"keyName"`
 }
 
 type Property struct {

--- a/services/softLayer_account.go
+++ b/services/softLayer_account.go
@@ -110,6 +110,35 @@ func (slas *softLayer_Account_Service) GetIscsiNetworkStorage() ([]datatypes.Sof
 	return networkStorage, nil
 }
 
+func (slas *softLayer_Account_Service) GetIscsiNetworkStorageWithFilter(filter string) ([]datatypes.SoftLayer_Network_Storage, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getIscsiNetworkStorage.json")
+
+	objectMasks := []string{
+		"username",
+		"accountId",
+		"capacityGb",
+		"id",
+		"billingItem.id",
+		"billingItem.orderItem.order.id",
+	}
+
+	responseBytes, err := slas.client.DoRawHttpRequestWithObjectFilterAndObjectMask(path, objectMasks, filter, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getIscsiNetworkStorage, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Network_Storage{}, errors.New(errorMessage)
+	}
+
+	networkStorage := []datatypes.SoftLayer_Network_Storage{}
+	err = json.Unmarshal(responseBytes, &networkStorage)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	return networkStorage, nil
+}
+
 func (slas *softLayer_Account_Service) GetVirtualDiskImages() ([]datatypes.SoftLayer_Virtual_Disk_Image, error) {
 	path := fmt.Sprintf("%s/%s", slas.GetName(), "getVirtualDiskImages.json")
 	responseBytes, err := slas.client.DoRawHttpRequest(path, "GET", &bytes.Buffer{})

--- a/services/softlayer_account_test.go
+++ b/services/softlayer_account_test.go
@@ -96,6 +96,19 @@ var _ = Describe("SoftLayer_Account_Service", func() {
 		})
 	})
 
+	Context("#GetIscsiNetworkStorageWithFilter", func() {
+		BeforeEach(func() {
+			fakeClient.DoRawHttpRequestResponse, err = common.ReadJsonTestFixtures("services", "SoftLayer_Account_Service_getNetworkStorage.json")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an array of datatypes.SoftLayer_Network_Storage", func() {
+			iscsiNetworkStorage, err := accountService.GetIscsiNetworkStorageWithFilter("fake-filter")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(iscsiNetworkStorage).ToNot(BeNil())
+		})
+	})
+
 	Context("#GetVirtualDiskImages", func() {
 		BeforeEach(func() {
 			fakeClient.DoRawHttpRequestResponse, err = common.ReadJsonTestFixtures("services", "SoftLayer_Account_Service_getVirtualDiskImages.json")

--- a/services/softlayer_network_storage_test.go
+++ b/services/softlayer_network_storage_test.go
@@ -44,6 +44,10 @@ var _ = Describe("SoftLayer_Network_Storage", func() {
 	})
 
 	Context("#CreateIscsiVolume", func() {
+		BeforeEach(func() {
+			fakeClient.DoRawHttpRequestResponse, err = common.ReadJsonTestFixtures("services", "SoftLayer_Network_Storage_Service_getIscsiVolume.json")
+			Expect(err).ToNot(HaveOccurred())
+		})
 		It("fails with error if the volume size is negative", func() {
 			_, err := networkStorageService.CreateIscsiVolume(-1, "fake-location")
 			Expect(err).To(HaveOccurred())

--- a/services/softlayer_product_package.go
+++ b/services/softlayer_product_package.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	datatypes "github.com/maximilien/softlayer-go/data_types"
 	softlayer "github.com/maximilien/softlayer-go/softlayer"
@@ -25,6 +26,24 @@ func (slpp *softLayer_Product_Package_Service) GetName() string {
 
 func (slpp *softLayer_Product_Package_Service) GetItemPrices(packageId int) ([]datatypes.SoftLayer_Item_Price, error) {
 	response, err := slpp.client.DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getItemPrices.json", slpp.GetName(), packageId), []string{"id", "item.id", "item.description", "item.capacity"}, "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Item_Price{}, err
+	}
+
+	itemPrices := []datatypes.SoftLayer_Item_Price{}
+	err = json.Unmarshal(response, &itemPrices)
+	if err != nil {
+		return []datatypes.SoftLayer_Item_Price{}, err
+	}
+
+	return itemPrices, nil
+}
+
+func (slpp *softLayer_Product_Package_Service) GetItemPricesBySize(packageId int, size int) ([]datatypes.SoftLayer_Item_Price, error) {
+	keyName := strconv.Itoa(size) +"_GB_PERFORMANCE_STORAGE_SPACE"
+
+	filter := string(`{"itemPrices":{"item":{"keyName":{"operation":"`+keyName+`"}}}}`)
+	response, err := slpp.client.DoRawHttpRequestWithObjectFilterAndObjectMask(fmt.Sprintf("%s/%d/getItemPrices.json", slpp.GetName(), packageId), []string{"id","locationGroupId","item.id","item.keyName","item.units","item.description","item.capacity"},fmt.Sprintf(string(filter)),"GET", new(bytes.Buffer))
 	if err != nil {
 		return []datatypes.SoftLayer_Item_Price{}, err
 	}

--- a/services/softlayer_product_package.go
+++ b/services/softlayer_product_package.go
@@ -40,10 +40,10 @@ func (slpp *softLayer_Product_Package_Service) GetItemPrices(packageId int) ([]d
 }
 
 func (slpp *softLayer_Product_Package_Service) GetItemPricesBySize(packageId int, size int) ([]datatypes.SoftLayer_Item_Price, error) {
-	keyName := strconv.Itoa(size) +"_GB_PERFORMANCE_STORAGE_SPACE"
+	keyName := strconv.Itoa(size) + "_GB_PERFORMANCE_STORAGE_SPACE"
+	filter := string(`{"itemPrices":{"item":{"keyName":{"operation":"` + keyName + `"}}}}`)
 
-	filter := string(`{"itemPrices":{"item":{"keyName":{"operation":"`+keyName+`"}}}}`)
-	response, err := slpp.client.DoRawHttpRequestWithObjectFilterAndObjectMask(fmt.Sprintf("%s/%d/getItemPrices.json", slpp.GetName(), packageId), []string{"id","locationGroupId","item.id","item.keyName","item.units","item.description","item.capacity"},fmt.Sprintf(string(filter)),"GET", new(bytes.Buffer))
+	response, err := slpp.client.DoRawHttpRequestWithObjectFilterAndObjectMask(fmt.Sprintf("%s/%d/getItemPrices.json", slpp.GetName(), packageId), []string{"id", "locationGroupId", "item.id", "item.keyName", "item.units", "item.description", "item.capacity"}, fmt.Sprintf(string(filter)), "GET", new(bytes.Buffer))
 	if err != nil {
 		return []datatypes.SoftLayer_Item_Price{}, err
 	}

--- a/services/softlayer_product_package_test.go
+++ b/services/softlayer_product_package_test.go
@@ -57,4 +57,19 @@ var _ = Describe("SoftLayer_Product_Package", func() {
 			Expect(itemPrices[0].Item.Id).To(Equal(456))
 		})
 	})
+
+	Context("#GetItemPricesBySize", func() {
+		BeforeEach(func() {
+			fakeClient.DoRawHttpRequestResponse, err = common.ReadJsonTestFixtures("services", "SoftLayer_Product_Package_getItemPrices.json")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an array of datatypes.SoftLayer_Item_Price", func() {
+			itemPrices, err := productPackageService.GetItemPricesBySize(222, 20)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(itemPrices)).To(Equal(1))
+			Expect(itemPrices[0].Id).To(Equal(123))
+			Expect(itemPrices[0].Item.Id).To(Equal(456))
+		})
+	})
 })

--- a/softlayer/client.go
+++ b/softlayer/client.go
@@ -20,6 +20,7 @@ type Client interface {
 
 	DoRawHttpRequest(path string, requestType string, requestBody *bytes.Buffer) ([]byte, error)
 	DoRawHttpRequestWithObjectMask(path string, masks []string, requestType string, requestBody *bytes.Buffer) ([]byte, error)
+	DoRawHttpRequestWithObjectFilterAndObjectMask(path string, masks []string, filters string, requestType string, requestBody *bytes.Buffer) ([]byte, error)
 	GenerateRequestBody(templateData interface{}) (*bytes.Buffer, error)
 	HasErrors(body map[string]interface{}) error
 

--- a/softlayer/softlayer_account_service.go
+++ b/softlayer/softlayer_account_service.go
@@ -11,6 +11,7 @@ type SoftLayer_Account_Service interface {
 	GetVirtualGuests() ([]datatypes.SoftLayer_Virtual_Guest, error)
 	GetNetworkStorage() ([]datatypes.SoftLayer_Network_Storage, error)
 	GetIscsiNetworkStorage() ([]datatypes.SoftLayer_Network_Storage, error)
+	GetIscsiNetworkStorageWithFilter(filter string) ([]datatypes.SoftLayer_Network_Storage, error)
 	GetVirtualDiskImages() ([]datatypes.SoftLayer_Virtual_Disk_Image, error)
 	GetSshKeys() ([]datatypes.SoftLayer_Security_Ssh_Key, error)
 	GetBlockDeviceTemplateGroups() ([]datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group, error)

--- a/softlayer/softlayer_network_storage_service.go
+++ b/softlayer/softlayer_network_storage_service.go
@@ -10,5 +10,4 @@ type SoftLayer_Network_Storage_Service interface {
 	CreateIscsiVolume(size int, location string) (datatypes.SoftLayer_Network_Storage, error)
 	DeleteIscsiVolume(volumeId int, immediateCancellationFlag bool) error
 	GetIscsiVolume(volumeId int) (datatypes.SoftLayer_Network_Storage, error)
-
 }

--- a/softlayer/softlayer_network_storage_service.go
+++ b/softlayer/softlayer_network_storage_service.go
@@ -10,4 +10,5 @@ type SoftLayer_Network_Storage_Service interface {
 	CreateIscsiVolume(size int, location string) (datatypes.SoftLayer_Network_Storage, error)
 	DeleteIscsiVolume(volumeId int, immediateCancellationFlag bool) error
 	GetIscsiVolume(volumeId int) (datatypes.SoftLayer_Network_Storage, error)
+
 }

--- a/softlayer/softlayer_product_package_service.go
+++ b/softlayer/softlayer_product_package_service.go
@@ -8,4 +8,5 @@ type SoftLayer_Product_Package_Service interface {
 	Service
 
 	GetItemPrices(packageId int) ([]datatypes.SoftLayer_Item_Price, error)
+	GetItemPricesBySize(packageId int, size int) ([]datatypes.SoftLayer_Item_Price, error)
 }

--- a/test_fixtures/services/SoftLayer_Product_Package_getItemPrices.json
+++ b/test_fixtures/services/SoftLayer_Product_Package_getItemPrices.json
@@ -1,10 +1,16 @@
 [
-	{
-		"id": 123,
-		"item": {
-			"id": 456,
-			"capacity": "20",
-			"description": "20GB iSCSI SAN Disk"
-		}
+  {
+	"id": 123,
+	"locationGroupId": null,
+	"item": {
+	  "capacity": "20",
+	  "description": "20 GB Storage Space",
+	  "id": 456,
+	  "keyName": "20_GB_PERFORMANCE_STORAGE_SPACE",
+	  "units": "GB"
 	}
+  }
 ]
+
+
+


### PR DESCRIPTION
As SL no longer provided the ordering of legacy iscsi disk, softlayer-go needs to make corresponding changes to support consistent performance iscsi disk.
In order to enhance the efficiency of calling softlayer rest api, I created a new kind of http request in softlayer client. Several query methods in softlayer services had been added to leveraging filter function. For example, in production environment, there are a fair mount of storage, itemprice, blockdevicetemplates, etc. So it is better to filtering objects than traversing the result set multiple times.

New http request with objectFilter parameter in softlayer_client.go:

```go
func (slc *softLayerClient) DoRawHttpRequestWithObjectFilterAndObjectMask(path string, masks []string, filters string, requestType string, requestBody *bytes.Buffer) ([]byte, error) {
	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.apiKey, SOFTLAYER_API_URL, path)
	url += "?objectFilter=" + filters
	url += "&objectMask=filteredMask["
	for i := 0; i < len(masks); i++ {
		url += masks[i]
		if i != len(masks)-1 {
			url += ";"
		}
	}
	url += "]"
	return slc.makeHttpRequest(url, requestType, requestBody)
}
```

SoftLayer_Product_Package_Service.go
`+ GetItemPricesBySize(packageId int, size int) ([]datatypes.SoftLayer_Item_Price, error)`

SoftLayer_Account_Service.go
`+ GetIscsiNetworkStorageWithFilter(filter string) ([]datatypes.SoftLayer_Network_Storage, error)`