### PR TITLE
Add "network" option

### DIFF
--- a/data_types/softlayer_virtual_guest.go
+++ b/data_types/softlayer_virtual_guest.go
@@ -37,6 +37,7 @@ type SoftLayer_Virtual_Guest struct {
 
 	Location   *SoftLayer_Location `json:"location"`
 	Datacenter *SoftLayer_Location `json:"datacenter"`
+	NetworkComponents []NetworkComponents `json:"networkComponents,omitempty"`
 
 	OperatingSystem *SoftLayer_Operating_System `json:"operatingSystem"`
 }

--- a/services/softlayer_virtual_guest.go
+++ b/services/softlayer_virtual_guest.go
@@ -103,6 +103,7 @@ func (slvgs *softLayer_Virtual_Guest_Service) GetObject(instanceId int) (datatyp
 		"datacenter.name",
 		"datacenter.longName",
 		"datacenter.id",
+		"networkComponents.maxSpeed",
 		"operatingSystem.passwords.password",
 		"operatingSystem.passwords.username",
 	}

--- a/services/softlayer_virtual_guest_test.go
+++ b/services/softlayer_virtual_guest_test.go
@@ -69,6 +69,9 @@ var _ = Describe("SoftLayer_Virtual_Guest_Service", func() {
 				HourlyBillingFlag:            true,
 				LocalDiskFlag:                false,
 				DedicatedAccountHostOnlyFlag: false,
+				NetworkComponents: []datatypes.NetworkComponents{datatypes.NetworkComponents{
+					MaxSpeed: 10,
+				}},
 			}
 			virtualGuest, err = virtualGuestService.CreateObject(virtualGuestTemplate)
 			Expect(err).ToNot(HaveOccurred())
@@ -128,6 +131,7 @@ var _ = Describe("SoftLayer_Virtual_Guest_Service", func() {
 			Expect(vg.Datacenter.Id).To(Equal(456))
 			Expect(vg.Datacenter.Name).To(Equal("bej2"))
 			Expect(vg.Datacenter.LongName).To(Equal("Beijing 2"))
+			Expect(vg.NetworkComponents[0].MaxSpeed).To(Equal(100))
 			Expect(len(vg.OperatingSystem.Passwords)).To(BeNumerically(">=", 1))
 			Expect(vg.OperatingSystem.Passwords[0].Password).To(Equal("test_password"))
 			Expect(vg.OperatingSystem.Passwords[0].Username).To(Equal("test_username"))

--- a/test_fixtures/services/SoftLayer_Virtual_Guest_Service_getObject.json
+++ b/test_fixtures/services/SoftLayer_Virtual_Guest_Service_getObject.json
@@ -29,6 +29,11 @@
 		"name": "bej2",
 		"longName": "Beijing 2"
 	},
+    "networkComponents": [
+	  {
+		"maxSpeed": 100
+	  }
+	],
 	"operatingSystem": {
 		"passwords": [
 			{


### PR DESCRIPTION
When creating virtual guests, SoftLayer lets you
specify maximum network speed; 10, 100 or 1000 Mbps.
This adds the possibility to fetch the configured
speed from the GetObject call.