### PR TITLE
Use environment variable for Datacenter

### DIFF
--- a/test_helpers/test_helpers.go
+++ b/test_helpers/test_helpers.go
@@ -29,9 +29,9 @@ var (
 )
 
 const (
-	TEST_NOTES_PREFIX = "TEST:softlayer-go"
-	TEST_LABEL_PREFIX = "TEST:softlayer-go"
-	DATACENTER        = "dal09"
+	TEST_NOTES_PREFIX  = "TEST:softlayer-go"
+	TEST_LABEL_PREFIX  = "TEST:softlayer-go"
+	DEFAULT_DATACENTER = "dal09"
 
 	MAX_WAIT_RETRIES = 10
 	WAIT_TIME        = 5
@@ -138,6 +138,14 @@ func GetUsernameAndApiKey() (string, string, error) {
 	}
 
 	return username, apiKey, nil
+}
+
+func GetDatacenter() string {
+	datacenter := os.Getenv("SL_DATACENTER")
+	if datacenter == "" {
+		datacenter = DEFAULT_DATACENTER
+	}
+	return datacenter
 }
 
 func CreateAccountService() (softlayer.SoftLayer_Account_Service, error) {
@@ -356,7 +364,7 @@ func CreateVirtualGuestAndMarkItTest(securitySshKeys []datatypes.SoftLayer_Secur
 		StartCpus: 1,
 		MaxMemory: 1024,
 		Datacenter: datatypes.Datacenter{
-			Name: DATACENTER,
+			Name: GetDatacenter(),
 		},
 		SshKeys:                      sshKeys,
 		HourlyBillingFlag:            true,


### PR DESCRIPTION
renamed old DATACENTER constant to DEFAULT_DATACENTER, and only use it if the SL_DATACENTER environment variable is set; otherwise use $SL_DATACENTER