### PR TITLE
Added wait for vg to not have transactions before deleting ssh key

### DIFF
--- a/integration/virtual_guest_lifecycle/virtual_guest_lifecycle_test.go
+++ b/integration/virtual_guest_lifecycle/virtual_guest_lifecycle_test.go
@@ -163,6 +163,7 @@ var _ = Describe("SoftLayer Virtual Guest Lifecycle", func() {
 			testhelpers.WaitForVirtualGuestToHaveNoActiveTransactions(virtualGuest.Id)
 
 			testhelpers.DeleteVirtualGuest(virtualGuest.Id)
+			testhelpers.WaitForVirtualGuestToHaveNoActiveTransactionsOrToErr(virtualGuest.Id)
 			testhelpers.DeleteSshKey(createdSshKey.Id)
 		})
 	})


### PR DESCRIPTION
I hit an error in the integration test on my dev pipeline where the DeleteSshKey failed because there were still active transactions.
This should prevent that happening in the future.