### PR TITLE
Fixed delete_disk bug

### DIFF
--- a/services/softlayer_network_storage.go
+++ b/services/softlayer_network_storage.go
@@ -162,6 +162,7 @@ func (slns *softLayer_Network_Storage_Service) GetIscsiVolume(volumeId int) (dat
 	}
 
 	response, err := slns.client.DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getObject.json", slns.GetName(), volumeId), objectMask, "GET", new(bytes.Buffer))
+
 	if err != nil {
 		return datatypes.SoftLayer_Network_Storage{}, err
 	}
@@ -196,7 +197,7 @@ func (slns *softLayer_Network_Storage_Service) HasAllowedVirtualGuest(volumeId i
 	return false, nil
 }
 
-func (slns *softLayer_Network_Storage_Service) AttachIscsiVolume(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) (string, error) {
+func (slns *softLayer_Network_Storage_Service) AttachIscsiVolume(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) (bool, error) {
 	parameters := datatypes.SoftLayer_Virtual_Guest_Parameters{
 		Parameters: []datatypes.SoftLayer_Virtual_Guest{
 			virtualGuest,
@@ -204,12 +205,17 @@ func (slns *softLayer_Network_Storage_Service) AttachIscsiVolume(virtualGuest da
 	}
 	requestBody, err := json.Marshal(parameters)
 	if err != nil {
-		return "", err
+		return false, err
 	}
 
 	resp, err := slns.client.DoRawHttpRequest(fmt.Sprintf("%s/%d/allowAccessFromVirtualGuest.json", slns.GetName(), volumeId), "PUT", bytes.NewBuffer(requestBody))
 
-	return string(resp[:]), err
+	allowable, err := strconv.ParseBool(string(resp[:]))
+	if err != nil {
+		return false, nil
+	}
+
+	return allowable, nil
 }
 
 func (slns *softLayer_Network_Storage_Service) DetachIscsiVolume(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) error {

--- a/services/softlayer_network_storage_test.go
+++ b/services/softlayer_network_storage_test.go
@@ -103,7 +103,7 @@ var _ = Describe("SoftLayer_Network_Storage", func() {
 			fakeClient.DoRawHttpRequestResponse = []byte("true")
 			resp, err := networkStorageService.AttachIscsiVolume(virtualGuest, 123)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(resp).To(Equal("true"))
+			Expect(resp).To(Equal(true))
 		})
 	})
 

--- a/softlayer/softlayer_network_storage_service.go
+++ b/softlayer/softlayer_network_storage_service.go
@@ -11,6 +11,6 @@ type SoftLayer_Network_Storage_Service interface {
 	DeleteIscsiVolume(volumeId int, immediateCancellationFlag bool) error
 	GetIscsiVolume(volumeId int) (datatypes.SoftLayer_Network_Storage, error)
 	HasAllowedVirtualGuest(volumeId int, vmId int) (bool, error)
-	AttachIscsiVolume(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) (string, error)
+	AttachIscsiVolume(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) (bool, error)
 	DetachIscsiVolume(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) error
 }

--- a/softlayer/softlayer_network_storage_service.go
+++ b/softlayer/softlayer_network_storage_service.go
@@ -7,6 +7,8 @@ import (
 type SoftLayer_Network_Storage_Service interface {
 	Service
 
+	DeleteObject(volumeId int) (bool, error)
+
 	CreateIscsiVolume(size int, location string) (datatypes.SoftLayer_Network_Storage, error)
 	DeleteIscsiVolume(volumeId int, immediateCancellationFlag bool) error
 	GetIscsiVolume(volumeId int) (datatypes.SoftLayer_Network_Storage, error)


### PR DESCRIPTION
Fixed the following panic exception

```
/Users/jianqiu/Workspace/softlayer-go/src/github.com/cloudfoundry/bosh-utils/logger/logger.go:146 (0x7bece)
	(*logger).HandlePanic: l.ErrorWithDetails(tag, "Panic: %s", msg, debug.Stack())
/usr/local/go/src/runtime/asm_amd64.s:402 (0x284c5)
	call32: CALLFN(·call32, 32)
/usr/local/go/src/runtime/panic.go:387 (0x15548)
	gopanic: reflectcall(unsafe.Pointer(d.fn), deferArgs(d), uint32(d.siz), uint32(d.siz))
/usr/local/go/src/runtime/panic.go:42 (0x1486e)
	panicmem: panic(memoryError)
/usr/local/go/src/runtime/sigpanic_unix.go:26 (0x1acd0)
	sigpanic: panicmem()
/Users/jianqiu/Workspace/softlayer-go/src/github.com/maximilien/softlayer-go/services/softlayer_network_storage.go:114 (0x186e24)
	(*softLayer_Network_Storage_Service).DeleteIscsiVolume: billingItemId = iscsiStorages[i].BillingItem.Id
/Users/jianqiu/Workspace/softlayer-go/src/github.com/maximilien/bosh-softlayer-cpi/softlayer/disk/softlayer_disk.go:35 (0x11159f)
	SoftLayerDisk.Delete: err = service.DeleteIscsiVolume(s.id, true)
<autogenerated>:6 (0x112442)
/Users/jianqiu/Workspace/softlayer-go/src/github.com/maximilien/bosh-softlayer-cpi/action/delete_disk.go:24 (0x66f93)
	DeleteDisk.Run: err := disk.Delete()
<autogenerated>:21 (0x6b19d)
/usr/local/go/src/runtime/asm_amd64.s:403 (0x28535)
	call64: CALLFN(·call64, 64)
/usr/local/go/src/reflect/value.go:419 (0xaeaa5)
	Value.call: call(fn, args, uint32(frametype.size), uint32(retOffset))
/usr/local/go/src/reflect/value.go:296 (0xad89c)
	Value.Call: return v.call("Call", in)
/Users/jianqiu/Workspace/softlayer-go/src/github.com/maximilien/bosh-softlayer-cpi/api/dispatcher/json_caller.go:43 (0x82b39)
	JSONCaller.Call: values := runMethodValue.Call(methodArgs)
<autogenerated>:6 (0x84399)
/Users/jianqiu/Workspace/softlayer-go/src/github.com/maximilien/bosh-softlayer-cpi/api/dispatcher/json.go:84 (0x8197f)
	JSON.Dispatch: result, err := c.caller.Call(action, req.Arguments)
<autogenerated>:2 (0x83b15)
/Users/jianqiu/Workspace/softlayer-go/src/github.com/maximilien/bosh-softlayer-cpi/api/transport/cli.go:43 (0x84a2a)
	CLI.ServeOnce: respBytes := t.dispatcher.Dispatch(reqBytes)
/Users/jianqiu/Workspace/softlayer-go/src/github.com/maximilien/bosh-softlayer-cpi/main/main.go:41 (0x2a21)
	main: err = cli.ServeOnce()
/usr/local/go/src/runtime/proc.go:63 (0x17093)
	main: main_main()
/usr/local/go/src/runtime/asm_amd64.s:2232 (0x2a591)
```