### PR TITLE
Added changes for https://github.com/maximilien/softlayer-go/pull/84

### DIFF
--- a/client/fakes/softlayer_client_fake.go
+++ b/client/fakes/softlayer_client_fake.go
@@ -189,13 +189,13 @@ func (fslc *FakeSoftLayerClient) GetSoftLayer_Hardware_Service() (softlayer.Soft
 	return slService.(softlayer.SoftLayer_Hardware_Service), nil
 }
 
-func (fslc *FakeSoftLayerClient) GetSoftLayer_Dns_Domain_Resource_Record_Service() (softlayer.SoftLayer_Dns_Domain_Resource_Record_Service, error) {
+func (fslc *FakeSoftLayerClient) GetSoftLayer_Dns_Domain_ResourceRecord_Service() (softlayer.SoftLayer_Dns_Domain_ResourceRecord_Service, error) {
 	slService, err := fslc.GetService("SoftLayer_Dns_Domain_ResourceRecord")
 	if err != nil {
 		return nil, err
 	}
 
-	return slService.(softlayer.SoftLayer_Dns_Domain_Resource_Record_Service), nil
+	return slService.(softlayer.SoftLayer_Dns_Domain_ResourceRecord_Service), nil
 }
 
 //Public methods
@@ -298,5 +298,5 @@ func (fslc *FakeSoftLayerClient) initSoftLayerServices() {
 	fslc.SoftLayerServices["SoftLayer_Virtual_Guest_Block_Device_Template_Group"] = services.NewSoftLayer_Virtual_Guest_Block_Device_Template_Group_Service(fslc)
 	fslc.SoftLayerServices["SoftLayer_Hardware"] = services.NewSoftLayer_Hardware_Service(fslc)
 	fslc.SoftLayerServices["SoftLayer_Dns_Domain"] = services.NewSoftLayer_Dns_Domain_Service(fslc)
-	fslc.SoftLayerServices["SoftLayer_Dns_Domain_ResourceRecord"] = services.NewSoftLayer_Dns_Domain_Resource_Record_Service(fslc)
+	fslc.SoftLayerServices["SoftLayer_Dns_Domain_ResourceRecord"] = services.NewSoftLayer_Dns_Domain_ResourceRecord_Service(fslc)
 }

--- a/client/softlayer_client.go
+++ b/client/softlayer_client.go
@@ -178,13 +178,13 @@ func (slc *SoftLayerClient) GetSoftLayer_Hardware_Service() (softlayer.SoftLayer
 	return slService.(softlayer.SoftLayer_Hardware_Service), nil
 }
 
-func (slc *SoftLayerClient) GetSoftLayer_Dns_Domain_Resource_Record_Service() (softlayer.SoftLayer_Dns_Domain_Resource_Record_Service, error) {
+func (slc *SoftLayerClient) GetSoftLayer_Dns_Domain_ResourceRecord_Service() (softlayer.SoftLayer_Dns_Domain_ResourceRecord_Service, error) {
 	slService, err := slc.GetService("SoftLayer_Dns_Domain_ResourceRecord")
 	if err != nil {
 		return nil, err
 	}
 
-	return slService.(softlayer.SoftLayer_Dns_Domain_Resource_Record_Service), nil
+	return slService.(softlayer.SoftLayer_Dns_Domain_ResourceRecord_Service), nil
 }
 
 //Public methods
@@ -282,7 +282,7 @@ func (slc *SoftLayerClient) initSoftLayerServices() {
 	slc.softLayerServices["SoftLayer_Virtual_Guest_Block_Device_Template_Group"] = services.NewSoftLayer_Virtual_Guest_Block_Device_Template_Group_Service(slc)
 	slc.softLayerServices["SoftLayer_Hardware"] = services.NewSoftLayer_Hardware_Service(slc)
 	slc.softLayerServices["SoftLayer_Dns_Domain"] = services.NewSoftLayer_Dns_Domain_Service(slc)
-	slc.softLayerServices["SoftLayer_Dns_Domain_ResourceRecord"] = services.NewSoftLayer_Dns_Domain_Resource_Record_Service(slc)
+	slc.softLayerServices["SoftLayer_Dns_Domain_ResourceRecord"] = services.NewSoftLayer_Dns_Domain_ResourceRecord_Service(slc)
 }
 
 func hideCredentials(s string) string {

--- a/data_types/softlayer_container_product_order.go
+++ b/data_types/softlayer_container_product_order.go
@@ -21,7 +21,7 @@ type SoftLayer_Container_Product_Order struct {
 	ComplexType   string                 `json:"complexType"`
 	Location      string                 `json:"location,omitempty"`
 	PackageId     int                    `json:"packageId"`
-	Prices        []SoftLayer_Item_Price `json:"prices,omitempty"`
+	Prices        []SoftLayer_Product_Item_Price `json:"prices,omitempty"`
 	VirtualGuests []VirtualGuest         `json:"virtualGuests,omitempty"`
 	Properties    []Property             `json:"properties,omitempty"`
 	Quantity      int                    `json:"quantity,omitempty"`
@@ -32,7 +32,7 @@ type SoftLayer_Container_Product_Order_Network_PerformanceStorage_Iscsi struct {
 	ComplexType   string                                  `json:"complexType"`
 	Location      string                                  `json:"location,omitempty"`
 	PackageId     int                                     `json:"packageId"`
-	Prices        []SoftLayer_Item_Price                  `json:"prices,omitempty"`
+	Prices        []SoftLayer_Product_Item_Price                  `json:"prices,omitempty"`
 	VirtualGuests []VirtualGuest                          `json:"virtualGuests,omitempty"`
 	Properties    []Property                              `json:"properties,omitempty"`
 	Quantity      int                                     `json:"quantity,omitempty"`
@@ -44,7 +44,7 @@ type SoftLayer_Container_Product_Order_Virtual_Guest_Upgrade struct {
 	ComplexType   string                 `json:"complexType"`
 	Location      string                 `json:"location,omitempty"`
 	PackageId     int                    `json:"packageId"`
-	Prices        []SoftLayer_Item_Price `json:"prices,omitempty"`
+	Prices        []SoftLayer_Product_Item_Price `json:"prices,omitempty"`
 	VirtualGuests []VirtualGuest         `json:"virtualGuests,omitempty"`
 	Properties    []Property             `json:"properties,omitempty"`
 	Quantity      int                    `json:"quantity,omitempty"`

--- a/data_types/softlayer_dns_domain.go
+++ b/data_types/softlayer_dns_domain.go
@@ -10,10 +10,10 @@ type SoftLayer_Dns_Domain_Template_Parameters struct {
 }
 
 type SoftLayer_Dns_Domain struct {
-	Id         int    `json:"id"`
-	Name       string `json:"name"`
-	Serial     int    `json:"serial"`
-	UpdateDate string `json:"updateDate"`
+	Id                  uint32                                 `json:"id"`
+	Name                string                                 `json:"name"`
+	Serial              uint32                                 `json:"serial"`
+	UpdateDate          string                                 `json:"updateDate"`
 	ManagedResourceFlag bool                                   `json:"managedResourceFlag"`
 	ResourceRecordCount int                                    `json:"resourceRecordCount"`
 	ResourceRecords     []SoftLayer_Dns_Domain_Resource_Record `json:"resourceRecords"`

--- a/data_types/softlayer_dns_domain_record.go
+++ b/data_types/softlayer_dns_domain_record.go
@@ -6,10 +6,10 @@ type SoftLayer_Dns_Domain_Resource_Record_Template_Parameters struct {
 
 type SoftLayer_Dns_Domain_Resource_Record_Template struct {
 	Data              string `json:"data"`
-	DomainId          int    `json:"domainId"`
+	DomainId          uint32 `json:"domainId"`
 	Expire            int    `json:"expire"`
 	Host              string `json:"host"`
-	Id                int    `json:"id"`
+	Id                uint32 `json:"id"`
 	Minimum           int    `json:"minimum"`
 	MxPriority        int    `json:"mxPriority"`
 	Refresh           int    `json:"refresh"`
@@ -30,10 +30,10 @@ type SoftLayer_Dns_Domain_Resource_Record_Parameters struct {
 
 type SoftLayer_Dns_Domain_Resource_Record struct {
 	Data              string `json:"data"`
-	DomainId          int    `json:"domainId"`
+	DomainId          uint32 `json:"domainId"`
 	Expire            int    `json:"expire"`
 	Host              string `json:"host"`
-	Id                int    `json:"id"`
+	Id                uint32 `json:"id"`
 	Minimum           int    `json:"minimum"`
 	MxPriority        int    `json:"mxPriority"`
 	Refresh           int    `json:"refresh"`

--- a/data_types/softlayer_product_item_price.go
+++ b/data_types/softlayer_product_item_price.go
@@ -1,0 +1,19 @@
+package data_types
+
+type SoftLayer_Product_Item_Price struct {
+	Id              uint32     `json:"id"`
+	LocationGroupId uint32     `json:"locationGroupId"`
+	Categories      []Category `json:"categories,omitempty"`
+	Item            *Item      `json:"item,omitempty"`
+}
+
+type Item struct {
+	Id          uint32 `json:"id"`
+	Description string `json:"description"`
+	Capacity    string `json:"capacity"`
+}
+
+type Category struct {
+	Id           uint32 `json:"id"`
+	CategoryCode string `json:"categoryCode"`
+}

--- a/data_types/softlayer_product_package.go
+++ b/data_types/softlayer_product_package.go
@@ -1,7 +1,7 @@
 package data_types
 
 type Softlayer_Product_Package struct {
-	Id          int           `json:"id"`
+	Id          uint32        `json:"id"`
 	Name        string        `json:"name"`
 	IsActive    int           `json:"isActive"`
 	Description string        `json:"description"`
@@ -13,8 +13,8 @@ type Package_Type struct {
 }
 
 type SoftLayer_Product_Item struct {
-	Id          int                    `json:"id"`
+	Id          uint32                 `json:"id"`
 	Description string                 `json:"description"`
 	Capacity    string                 `json:"capacity"`
-	Prices      []SoftLayer_Item_Price `json:"prices,omitempty"`
+	Prices      []SoftLayer_Product_Item_Price `json:"prices,omitempty"`
 }

--- a/integration/dns_domain_resource_record/dns_domain_resource_record_test.go
+++ b/integration/dns_domain_resource_record/dns_domain_resource_record_test.go
@@ -13,7 +13,7 @@ import (
 var _ = Describe("SoftLayer DNS Resource Records", func() {
 	var (
 		err								 error
-		dnsDomainResourceRecordService 	 softlayer.SoftLayer_Dns_Domain_Resource_Record_Service
+		dnsDomainResourceRecordService 	 softlayer.SoftLayer_Dns_Domain_ResourceRecord_Service
 		dnsDomainService 	 			 softlayer.SoftLayer_Dns_Domain_Service
 	)
 

--- a/services/softlayer_dns_domain_resource_record.go
+++ b/services/softlayer_dns_domain_resource_record.go
@@ -10,21 +10,21 @@ import (
 	softlayer "github.com/maximilien/softlayer-go/softlayer"
 )
 
-type softLayer_Dns_Domain_Resource_Record_Service struct {
+type SoftLayer_Dns_Domain_ResourceRecord_Service struct {
 	client softlayer.Client
 }
 
-func NewSoftLayer_Dns_Domain_Resource_Record_Service(client softlayer.Client) *softLayer_Dns_Domain_Resource_Record_Service {
-	return &softLayer_Dns_Domain_Resource_Record_Service{
+func NewSoftLayer_Dns_Domain_ResourceRecord_Service(client softlayer.Client) *SoftLayer_Dns_Domain_ResourceRecord_Service {
+	return &SoftLayer_Dns_Domain_ResourceRecord_Service{
 		client: client,
 	}
 }
 
-func (sldr *softLayer_Dns_Domain_Resource_Record_Service) GetName() string {
+func (sldr *SoftLayer_Dns_Domain_ResourceRecord_Service) GetName() string {
 	return "SoftLayer_Dns_Domain_ResourceRecord"
 }
 
-func (sldr *softLayer_Dns_Domain_Resource_Record_Service) CreateObject(template datatypes.SoftLayer_Dns_Domain_Resource_Record_Template) (datatypes.SoftLayer_Dns_Domain_Resource_Record, error) {
+func (sldr *SoftLayer_Dns_Domain_ResourceRecord_Service) CreateObject(template datatypes.SoftLayer_Dns_Domain_Resource_Record_Template) (datatypes.SoftLayer_Dns_Domain_Resource_Record, error) {
 	parameters := datatypes.SoftLayer_Dns_Domain_Resource_Record_Template_Parameters{
 		Parameters: []datatypes.SoftLayer_Dns_Domain_Resource_Record_Template{
 			template,
@@ -55,7 +55,7 @@ func (sldr *softLayer_Dns_Domain_Resource_Record_Service) CreateObject(template 
 	return dns_record, nil
 }
 
-func (sldr *softLayer_Dns_Domain_Resource_Record_Service) GetObject(id int) (datatypes.SoftLayer_Dns_Domain_Resource_Record, error) {
+func (sldr *SoftLayer_Dns_Domain_ResourceRecord_Service) GetObject(id int) (datatypes.SoftLayer_Dns_Domain_Resource_Record, error) {
 	objectMask := []string{
 		"data",
 		"domainId",
@@ -95,7 +95,7 @@ func (sldr *softLayer_Dns_Domain_Resource_Record_Service) GetObject(id int) (dat
 	return dns_record, nil
 }
 
-func (sldr *softLayer_Dns_Domain_Resource_Record_Service) DeleteObject(recordId int) (bool, error) {
+func (sldr *SoftLayer_Dns_Domain_ResourceRecord_Service) DeleteObject(recordId int) (bool, error) {
 	response, err := sldr.client.DoRawHttpRequest(fmt.Sprintf("%s/%d.json", sldr.GetName(), recordId), "DELETE", new(bytes.Buffer))
 
 	if res := string(response[:]); res != "true" {
@@ -105,7 +105,7 @@ func (sldr *softLayer_Dns_Domain_Resource_Record_Service) DeleteObject(recordId 
 	return true, err
 }
 
-func (sldr *softLayer_Dns_Domain_Resource_Record_Service) EditObject(recordId int, template datatypes.SoftLayer_Dns_Domain_Resource_Record) (bool, error) {
+func (sldr *SoftLayer_Dns_Domain_ResourceRecord_Service) EditObject(recordId int, template datatypes.SoftLayer_Dns_Domain_Resource_Record) (bool, error) {
 	parameters := datatypes.SoftLayer_Dns_Domain_Resource_Record_Parameters{
 		Parameters: []datatypes.SoftLayer_Dns_Domain_Resource_Record{
 			template,
@@ -128,7 +128,7 @@ func (sldr *softLayer_Dns_Domain_Resource_Record_Service) EditObject(recordId in
 
 //Private methods
 
-func (sldr *softLayer_Dns_Domain_Resource_Record_Service) getNameByType(dnsType string) string {
+func (sldr *SoftLayer_Dns_Domain_ResourceRecord_Service) getNameByType(dnsType string) string {
 	switch dnsType {
 	case "srv":
 		// Currently only SRV record type requires additional fields for Create and Update, while all other record types

--- a/services/softlayer_dns_domain_resource_record_test.go
+++ b/services/softlayer_dns_domain_resource_record_test.go
@@ -18,7 +18,7 @@ var _ = Describe("SoftLayer_Dns_Domain_Record", func() {
 
 		fakeClient *slclientfakes.FakeSoftLayerClient
 
-		dnsDomainResourceRecordService softlayer.SoftLayer_Dns_Domain_Resource_Record_Service
+		dnsDomainResourceRecordService softlayer.SoftLayer_Dns_Domain_ResourceRecord_Service
 		err                    error
 	)
 
@@ -32,7 +32,7 @@ var _ = Describe("SoftLayer_Dns_Domain_Record", func() {
 		fakeClient = slclientfakes.NewFakeSoftLayerClient(username, apiKey)
 		Expect(fakeClient).ToNot(BeNil())
 
-		dnsDomainResourceRecordService, err = fakeClient.GetSoftLayer_Dns_Domain_Resource_Record_Service()
+		dnsDomainResourceRecordService, err = fakeClient.GetSoftLayer_Dns_Domain_ResourceRecord_Service()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(dnsDomainResourceRecordService).ToNot(BeNil())
 	})
@@ -46,7 +46,7 @@ var _ = Describe("SoftLayer_Dns_Domain_Record", func() {
 
 	Context("#CreateObject", func() {
 		BeforeEach(func() {
-			fakeClient.DoRawHttpRequestResponse, err = testhelpers.ReadJsonTestFixtures("services", "SoftLayer_Dns_Domain_Resource_Record_Service_createObject.json")
+			fakeClient.DoRawHttpRequestResponse, err = testhelpers.ReadJsonTestFixtures("services", "SoftLayer_Dns_Domain_ResourceRecord_Service_createObject.json")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -96,7 +96,7 @@ var _ = Describe("SoftLayer_Dns_Domain_Record", func() {
 
 	Context("#GetObject", func() {
 		BeforeEach(func() {
-			fakeClient.DoRawHttpRequestResponse, err = testhelpers.ReadJsonTestFixtures("services", "SoftLayer_Dns_Domain_Resource_Record_Service_createObject.json")
+			fakeClient.DoRawHttpRequestResponse, err = testhelpers.ReadJsonTestFixtures("services", "SoftLayer_Dns_Domain_ResourceRecord_Service_createObject.json")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -120,7 +120,7 @@ var _ = Describe("SoftLayer_Dns_Domain_Record", func() {
 
 	Context("#EditObject", func() {
 		BeforeEach(func() {
-			fakeClient.DoRawHttpRequestResponse, err = testhelpers.ReadJsonTestFixtures("services", "SoftLayer_Dns_Domain_Resource_Record_Service_editObject.json")
+			fakeClient.DoRawHttpRequestResponse, err = testhelpers.ReadJsonTestFixtures("services", "SoftLayer_Dns_Domain_ResourceRecord_Service_editObject.json")
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/softlayer/client.go
+++ b/softlayer/client.go
@@ -19,7 +19,7 @@ type Client interface {
 	GetSoftLayer_Virtual_Guest_Block_Device_Template_Group_Service() (SoftLayer_Virtual_Guest_Block_Device_Template_Group_Service, error)
 	GetSoftLayer_Hardware_Service() (SoftLayer_Hardware_Service, error)
 	GetSoftLayer_Dns_Domain_Service() (SoftLayer_Dns_Domain_Service, error)
-	GetSoftLayer_Dns_Domain_Resource_Record_Service() (SoftLayer_Dns_Domain_Resource_Record_Service, error)
+	GetSoftLayer_Dns_Domain_ResourceRecord_Service() (SoftLayer_Dns_Domain_ResourceRecord_Service, error)
 
 	DoRawHttpRequest(path string, requestType string, requestBody *bytes.Buffer) ([]byte, error)
 	DoRawHttpRequestWithObjectMask(path string, masks []string, requestType string, requestBody *bytes.Buffer) ([]byte, error)

--- a/softlayer/softlayer_dns_domain_resource_record_service.go
+++ b/softlayer/softlayer_dns_domain_resource_record_service.go
@@ -4,7 +4,7 @@ import (
 	datatypes "github.com/maximilien/softlayer-go/data_types"
 )
 
-type SoftLayer_Dns_Domain_Resource_Record_Service interface {
+type SoftLayer_Dns_Domain_ResourceRecord_Service interface {
 	Service
 
 	CreateObject(template datatypes.SoftLayer_Dns_Domain_Resource_Record_Template) (datatypes.SoftLayer_Dns_Domain_Resource_Record, error)

--- a/test_helpers/test_helpers.go
+++ b/test_helpers/test_helpers.go
@@ -706,14 +706,14 @@ func CreateDnsDomainService() (softlayer.SoftLayer_Dns_Domain_Service, error) {
 	return dnsDomainService, nil
 }
 
-func CreateDnsDomainResourceRecordService() (softlayer.SoftLayer_Dns_Domain_Resource_Record_Service, error) {
+func CreateDnsDomainResourceRecordService() (softlayer.SoftLayer_Dns_Domain_ResourceRecord_Service, error) {
 	username, apiKey, err := GetUsernameAndApiKey()
 	if err != nil {
 		return nil, err
 	}
 
 	client := slclient.NewSoftLayerClient(username, apiKey)
-	dnsDomainResourceRecordService, err := client.GetSoftLayer_Dns_Domain_Resource_Record_Service()
+	dnsDomainResourceRecordService, err := client.GetSoftLayer_Dns_Domain_ResourceRecord_Service()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR fixes a service name that had an incorrect "_" throughout the newly added code ```SoftLayer_Dns_Domain_ResourceRecord_Service``` and it also changes ```int``` to ```uint32``` in our new code for any "id-type" field, some i held back on because I didn't have too much time to dig in, but all tests are passing:

```
./bin/test-unit

 Cleaning build artifacts...

 Formatting packages...

 Unit Testing packages:
[1453513380] SoftLayer Client Suite - 15/15 specs ••
---
[softlayer-go] Request:
application/text /rest/v3//foo HTTP/1.1
Host: api.softlayer.com

random text
••••••••••••• SUCCESS! 4.782814ms PASS
[1453513380] Services Suite - 118/118 specs •••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 79.598783ms PASS
[1453513380] Common Suite - 2/2 specs •• SUCCESS! 356.811µs PASS

Ginkgo ran 3 suites in 26.961100381s
Test Suite Passed

 Vetting packages for potential issues...

SWEET SUITE SUCCESS
```