### PR TITLE
bumping master: refactoring HttpClient to make it generic

### DIFF
--- a/client/fakes/http_client_fake.go
+++ b/client/fakes/http_client_fake.go
@@ -6,7 +6,7 @@ import (
 
 type FakeHttpClient struct {
 	Username string
-	ApiKey   string
+	Password string
 
 	DoRawHttpRequestInt            int
 	DoRawHttpRequestError          error
@@ -53,10 +53,10 @@ type FakeHttpClient struct {
 	CheckForHttpResponseErrorsError error
 }
 
-func NewFakeHttpClient(username, apiKey string) *FakeHttpClient {
+func NewFakeHttpClient(username, Password string) *FakeHttpClient {
 	return &FakeHttpClient{
 		Username: username,
-		ApiKey:   apiKey,
+		Password: Password,
 
 		DoRawHttpRequestInt:            200,
 		DoRawHttpRequestError:          nil,

--- a/client/http_client.go
+++ b/client/http_client.go
@@ -28,7 +28,7 @@ type HttpClient struct {
 const (
 	SOFTLAYER_API_URL  = "api.softlayer.com/rest/v3"
 	TEMPLATE_ROOT_PATH = "templates"
-	SL_GO_NON_VERBOSE  = "SL_GO_NON_VERBOSE"
+	NON_VERBOSE        = "NON_VERBOSE"
 )
 
 func NewHttpClient(username, apiKey string) *HttpClient {
@@ -181,7 +181,7 @@ func hideCredentials(s string) string {
 }
 
 func checkNonVerbose() bool {
-	slGoNonVerbose := os.Getenv(SL_GO_NON_VERBOSE)
+	slGoNonVerbose := os.Getenv(NON_VERBOSE)
 	switch slGoNonVerbose {
 	case "yes":
 		return true

--- a/client/http_client.go
+++ b/client/http_client.go
@@ -14,36 +14,37 @@ import (
 	"text/template"
 )
 
+const NON_VERBOSE = "NON_VERBOSE"
+
 type HttpClient struct {
 	HTTPClient *http.Client
 
 	username string
-	apiKey   string
+	password string
+
+	apiUrl string
 
 	nonVerbose bool
 
 	templatePath string
 }
 
-const (
-	SOFTLAYER_API_URL  = "api.softlayer.com/rest/v3"
-	TEMPLATE_ROOT_PATH = "templates"
-	NON_VERBOSE        = "NON_VERBOSE"
-)
-
-func NewHttpClient(username, apiKey string) *HttpClient {
+func NewHttpClient(username, password, apiUrl, templatePath string) *HttpClient {
 	pwd, err := os.Getwd()
 	if err != nil {
-		panic(err) // this should be handled by the user
+		panic(err)
 	}
 
 	hClient := &HttpClient{
 		username: username,
-		apiKey:   apiKey,
+		password: password,
 
-		templatePath: filepath.Join(pwd, TEMPLATE_ROOT_PATH),
+		apiUrl: apiUrl,
+
+		templatePath: filepath.Join(pwd, templatePath),
 
 		HTTPClient: http.DefaultClient,
+
 		nonVerbose: checkNonVerbose(),
 	}
 
@@ -53,7 +54,7 @@ func NewHttpClient(username, apiKey string) *HttpClient {
 // Public methods
 
 func (slc *HttpClient) DoRawHttpRequestWithObjectMask(path string, masks []string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error) {
-	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.apiKey, SOFTLAYER_API_URL, path)
+	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.password, slc.apiUrl, path)
 
 	url += "?objectMask="
 	for i := 0; i < len(masks); i++ {
@@ -67,14 +68,14 @@ func (slc *HttpClient) DoRawHttpRequestWithObjectMask(path string, masks []strin
 }
 
 func (slc *HttpClient) DoRawHttpRequestWithObjectFilter(path string, filters string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error) {
-	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.apiKey, SOFTLAYER_API_URL, path)
+	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.password, slc.apiUrl, path)
 	url += "?objectFilter=" + filters
 
 	return slc.makeHttpRequest(url, requestType, requestBody)
 }
 
 func (slc *HttpClient) DoRawHttpRequestWithObjectFilterAndObjectMask(path string, masks []string, filters string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error) {
-	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.apiKey, SOFTLAYER_API_URL, path)
+	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.password, slc.apiUrl, path)
 
 	url += "?objectFilter=" + filters
 
@@ -91,7 +92,7 @@ func (slc *HttpClient) DoRawHttpRequestWithObjectFilterAndObjectMask(path string
 }
 
 func (slc *HttpClient) DoRawHttpRequest(path string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error) {
-	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.apiKey, SOFTLAYER_API_URL, path)
+	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.password, slc.apiUrl, path)
 	return slc.makeHttpRequest(url, requestType, requestBody)
 }
 

--- a/client/softlayer_client.go
+++ b/client/softlayer_client.go
@@ -8,6 +8,11 @@ import (
 	softlayer "github.com/maximilien/softlayer-go/softlayer"
 )
 
+const (
+	SOFTLAYER_API_URL  = "api.softlayer.com/rest/v3"
+	TEMPLATE_ROOT_PATH = "templates"
+)
+
 type SoftLayerClient struct {
 	HttpClient softlayer.HttpClient
 
@@ -16,7 +21,7 @@ type SoftLayerClient struct {
 
 func NewSoftLayerClient(username, apiKey string) *SoftLayerClient {
 	slc := &SoftLayerClient{
-		HttpClient: NewHttpClient(username, apiKey),
+		HttpClient: NewHttpClient(username, apiKey, SOFTLAYER_API_URL, TEMPLATE_ROOT_PATH),
 
 		softLayerServices: map[string]softlayer.Service{},
 	}

--- a/client/softlayer_client_test.go
+++ b/client/softlayer_client_test.go
@@ -26,7 +26,7 @@ var _ = Describe("SoftLayerClient", func() {
 		username = os.Getenv("SL_USERNAME")
 		apiKey = os.Getenv("SL_API_KEY")
 
-		os.Setenv("SL_GO_NON_VERBOSE", "TRUE")
+		os.Setenv("NON_VERBOSE", "TRUE")
 
 		client = slclient.NewSoftLayerClient(username, apiKey)
 	})


### PR DESCRIPTION
1. injecting SL API URL into HttpClient instead of having constant (moved to the SoftLayerClient)
2. injecting `TEMPLATE_PATH` instead of having constant (moved to the SoftLayerClient)
2. renamed `SL_NON_VERBOSE` to `NON_VERBOSE`
3. renamed `apiKey` to `password` (that should not affect anyone, since it's private)

I don't expect any issues with CI but if you had setup `SL_NON_VERBOSE` env for debugging you now need to change to `NON_VERBOSE`

/cc @jianqiu @mattcui @zhanggong