### PR TITLE
Fix location problem in CreatePublicArchiveTransaction

### DIFF
--- a/services/softLayer_virtual_guest_block_device_template_group.go
+++ b/services/softLayer_virtual_guest_block_device_template_group.go
@@ -400,17 +400,12 @@ func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) Set
 }
 
 func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) CreatePublicArchiveTransaction(id int, groupName string, summary string, note string, locations []datatypes.SoftLayer_Location) (int, error) {
-	locationIdsArray := []int{}
-	for _, location := range locations {
-		locationIdsArray = append(locationIdsArray, location.Id)
-	}
-
 	groupName = url.QueryEscape(groupName)
 	summary = url.QueryEscape(summary)
 	note = url.QueryEscape(note)
 
 	parameters := datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_GroupInitParameters2{
-		Parameters: []interface{}{groupName, summary, note, locationIdsArray},
+		Parameters: []interface{}{groupName, summary, note, locations},
 	}
 
 	requestBody, err := json.Marshal(parameters)


### PR DESCRIPTION
Softlayer API CreatePublicArchiveTransaction can accept the "full" location, so don't need to make a new array which only contains location's ID.