### PR TITLE
Change to use 3 valued bool for LocalDiskFlag

### DIFF
--- a/data_types/softlayer_virtual_guest.go
+++ b/data_types/softlayer_virtual_guest.go
@@ -29,7 +29,7 @@ type SoftLayer_Virtual_Guest struct {
 	StartCpus                    int        `json:"startCpus,omitempty"`
 	StatusId                     int        `json:"statusId,omitempty"`
 	Uuid                         string     `json:"uuid,omitempty"`
-	LocalDiskFlag                bool       `json:"localDiskFlag,omitempty"`
+	LocalDiskFlag                *bool      `json:"localDiskFlag,omitempty"`
 	HourlyBillingFlag            bool       `json:"hourlyBillingFlag,omitempty"`
 
 	GlobalIdentifier        string `json:"globalIdentifier,omitempty"`
@@ -71,7 +71,7 @@ type SoftLayer_Virtual_Guest_Template struct {
 	MaxMemory         int        `json:"maxMemory"`
 	Datacenter        Datacenter `json:"datacenter"`
 	HourlyBillingFlag bool       `json:"hourlyBillingFlag"`
-	LocalDiskFlag     bool       `json:"localDiskFlag"`
+	LocalDiskFlag     *bool      `json:"localDiskFlag"`
 
 	//Conditionally required
 	OperatingSystemReferenceCode string                    `json:"operatingSystemReferenceCode,omitempty"`

--- a/services/softlayer_virtual_guest_test.go
+++ b/services/softlayer_virtual_guest_test.go
@@ -63,6 +63,8 @@ var _ = Describe("SoftLayer_Virtual_Guest_Service", func() {
 		BeforeEach(func() {
 			fakeClient.FakeHttpClient.DoRawHttpRequestResponse, err = testhelpers.ReadJsonTestFixtures("services", "SoftLayer_Virtual_Guest_Service_createObject.json")
 			Expect(err).ToNot(HaveOccurred())
+			f := new(bool)
+			*f = false
 
 			virtualGuestTemplate = datatypes.SoftLayer_Virtual_Guest_Template{
 				Hostname:  "fake-hostname",
@@ -73,7 +75,7 @@ var _ = Describe("SoftLayer_Virtual_Guest_Service", func() {
 					Name: "fake-datacenter-name",
 				},
 				HourlyBillingFlag:            true,
-				LocalDiskFlag:                false,
+				LocalDiskFlag:                f,
 				DedicatedAccountHostOnlyFlag: false,
 				NetworkComponents: []datatypes.NetworkComponents{datatypes.NetworkComponents{
 					MaxSpeed: 10,

--- a/test_helpers/test_helpers.go
+++ b/test_helpers/test_helpers.go
@@ -328,6 +328,8 @@ func CreateVirtualGuestAndMarkItTest(securitySshKeys []datatypes.SoftLayer_Secur
 	for i, securitySshKey := range securitySshKeys {
 		sshKeys[i] = datatypes.SshKey{Id: securitySshKey.Id}
 	}
+	t := new(bool)
+	*t = true
 
 	virtualGuestTemplate := datatypes.SoftLayer_Virtual_Guest_Template{
 		Hostname:  "test",
@@ -339,7 +341,7 @@ func CreateVirtualGuestAndMarkItTest(securitySshKeys []datatypes.SoftLayer_Secur
 		},
 		SshKeys:                      sshKeys,
 		HourlyBillingFlag:            true,
-		LocalDiskFlag:                true,
+		LocalDiskFlag:                t,
 		OperatingSystemReferenceCode: "UBUNTU_LATEST",
 	}
 


### PR DESCRIPTION
For addressing [Tracker 126049889](https://www.pivotaltracker.com/story/show/126049889), basically, we want to set true to LocalDiskFlag if it's not specified in the deployment manifest.