### PR TITLE
refactor GetDnsDomains(), fix #125

### DIFF
--- a/client/softlayer_client_test.go
+++ b/client/softlayer_client_test.go
@@ -196,7 +196,7 @@ var _ = Describe("SoftLayerClient", func() {
 				Expect(slApiEndPointUrl).To(Equal("api.service.softlayer.com/rest/v3"))
 			})
 		})
-	
+
 		Context("#when SL_API_ENDPOINT is NOT set correctly", func() {
 			It("returns the correct SL api endpoint url", func() {
 				os.Setenv("SL_API_ENDPOINT", "xxxxxx.softlayer.com")

--- a/services/softLayer_account.go
+++ b/services/softLayer_account.go
@@ -397,7 +397,7 @@ func (slas *softLayer_Account_Service) GetHardware() ([]datatypes.SoftLayer_Hard
 	return hardwares, nil
 }
 
-func (slas *softLayer_Account_Service) GetDnsDomains() ([]datatypes.SoftLayer_Dns_Domain, error) {
+func (slas *softLayer_Account_Service) GetDomains() ([]datatypes.SoftLayer_Dns_Domain, error) {
 	path := fmt.Sprintf("%s/%s", slas.GetName(), "getDomains.json")
 	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
 	if err != nil {

--- a/services/softlayer_account_test.go
+++ b/services/softlayer_account_test.go
@@ -511,4 +511,40 @@ var _ = Describe("SoftLayer_Account_Service", func() {
 			})
 		})
 	})
+
+	Context("#GetDomains", func() {
+		BeforeEach(func() {
+			fakeClient.FakeHttpClient.DoRawHttpRequestResponse, err = testhelpers.ReadJsonTestFixtures("services", "SoftLayer_Account_Service_getDomains.json")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns an array of datatypes.SoftLayer_Dns_Domain", func() {
+			dns_domains, err := accountService.GetDomains()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dns_domains).ToNot(BeNil())
+			Expect(len(dns_domains)).To(BeNumerically(">", 0))
+		})
+
+		Context("when HTTP client returns error codes 40x or 50x", func() {
+			It("fails for error code 40x", func() {
+				errorCodes := []int{400, 401, 499}
+				for _, errorCode := range errorCodes {
+					fakeClient.FakeHttpClient.DoRawHttpRequestInt = errorCode
+
+					_, err := accountService.GetDomains()
+					Expect(err).To(HaveOccurred())
+				}
+			})
+
+			It("fails for error code 50x", func() {
+				errorCodes := []int{500, 501, 599}
+				for _, errorCode := range errorCodes {
+					fakeClient.FakeHttpClient.DoRawHttpRequestInt = errorCode
+
+					_, err := accountService.GetDomains()
+					Expect(err).To(HaveOccurred())
+				}
+			})
+		})
+	})
 })

--- a/softlayer/softlayer_account_service.go
+++ b/softlayer/softlayer_account_service.go
@@ -20,4 +20,5 @@ type SoftLayer_Account_Service interface {
 	GetBlockDeviceTemplateGroupsWithFilter(filters string) ([]datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group, error)
 	GetDatacentersWithSubnetAllocations() ([]datatypes.SoftLayer_Location, error)
 	GetHardware() ([]datatypes.SoftLayer_Hardware, error)
+	GetDomains() ([]datatypes.SoftLayer_Dns_Domain, error)
 }

--- a/test_fixtures/services/SoftLayer_Account_Service_getDomains.json
+++ b/test_fixtures/services/SoftLayer_Account_Service_getDomains.json
@@ -1,0 +1,206 @@
+[
+	{
+		"id": 1671313,
+		"name": "awh.services.dal.bluemix.net",
+		"serial": 2014092401,
+		"updateDate": "2014-09-25T04:11:03+08:00"
+	},
+	{
+		"id": 1909513,
+		"name": "bi.services.au-syd.bluemix.net",
+		"serial": 2016063000,
+		"updateDate": "2016-06-30T17:24:00+08:00"
+	},
+	{
+		"id": 1909516,
+		"name": "bi.services.au-syd.stage1.bluemix.net",
+		"serial": 2016031502,
+		"updateDate": "2016-03-16T07:27:44+08:00"
+	},
+	{
+		"id": 1809802,
+		"name": "bi.services.bluemix.net",
+		"serial": 2016072610,
+		"updateDate": "2016-07-27T10:49:49+08:00"
+	},
+	{
+		"id": 1665704,
+		"name": "bi.services.dal.bluemix.net",
+		"serial": 2016050600,
+		"updateDate": "2016-05-07T01:40:48+08:00"
+	},
+	{
+		"id": 1909512,
+		"name": "bi.services.eu-gb.bluemix.net",
+		"serial": 2016063001,
+		"updateDate": "2016-06-30T17:26:08+08:00"
+	},
+	{
+		"id": 1909515,
+		"name": "bi.services.eu-gb.stage1.bluemix.net",
+		"serial": 2016031507,
+		"updateDate": "2016-03-16T02:29:32+08:00"
+	},
+	{
+		"id": 1809801,
+		"name": "bi.services.stage1.bluemix.net",
+		"serial": 2015063012,
+		"updateDate": "2015-07-01T04:23:56+08:00"
+	},
+	{
+		"id": 1909511,
+		"name": "bi.services.us-south.bluemix.net",
+		"serial": 2016080901,
+		"updateDate": "2016-08-09T13:16:19+08:00"
+	},
+	{
+		"id": 1909514,
+		"name": "bi.services.us-south.stage1.bluemix.net",
+		"serial": 2016031507,
+		"updateDate": "2016-03-16T02:30:32+08:00"
+	},
+	{
+		"id": 1850731,
+		"name": "cds.services.au-syd.bluemix.net",
+		"serial": 2015110602,
+		"updateDate": "2015-11-07T09:12:27+08:00"
+	},
+	{
+		"id": 1850730,
+		"name": "cds.services.eu-gb.bluemix.net",
+		"serial": 2015110602,
+		"updateDate": "2015-11-07T09:12:27+08:00"
+	},
+	{
+		"id": 1850729,
+		"name": "cds.services.us-south.bluemix.net",
+		"serial": 2015121701,
+		"updateDate": "2015-12-18T05:43:20+08:00"
+	},
+	{
+		"id": 1840690,
+		"name": "messagehub.services.au-syd.bluemix.net",
+		"serial": 2016021900,
+		"updateDate": "2016-02-19T23:30:31+08:00"
+	},
+	{
+		"id": 1839405,
+		"name": "messagehub.services.eu-gb.bluemix.net",
+		"serial": 2016062300,
+		"updateDate": "2016-06-24T00:34:01+08:00"
+	},
+	{
+		"id": 1839404,
+		"name": "messagehub.services.us-south.bluemix.net",
+		"serial": 2016032412,
+		"updateDate": "2016-03-24T22:11:24+08:00"
+	},
+	{
+		"id": 1666930,
+		"name": "mql.services.dal.bluemix.net",
+		"serial": 2015032000,
+		"updateDate": "2015-03-20T23:27:39+08:00"
+	},
+	{
+		"id": 1824050,
+		"name": "pm20.services.eu-gb.bluemix.net",
+		"serial": 2015081902,
+		"updateDate": "2015-08-20T10:18:10+08:00"
+	},
+	{
+		"id": 1824051,
+		"name": "pm20.services.eu-gb.stage1.bluemix.net",
+		"serial": 2015081902,
+		"updateDate": "2015-08-20T10:48:55+08:00"
+	},
+	{
+		"id": 1824049,
+		"name": "pm20.services.stage1.us-south.bluemix.net",
+		"serial": 2015081902,
+		"updateDate": "2015-08-20T10:18:10+08:00"
+	},
+	{
+		"id": 1824048,
+		"name": "pm20.services.us-south.bluemix.net",
+		"serial": 2015081902,
+		"updateDate": "2015-08-20T10:18:09+08:00"
+	},
+	{
+		"id": 1791639,
+		"name": "pvt.services.eu-gb.bluemix.net",
+		"serial": 2016071401,
+		"updateDate": "2016-07-15T02:09:09+08:00"
+	},
+	{
+		"id": 1795312,
+		"name": "pvt.services.ng.bluemix.net",
+		"serial": 2015061507,
+		"updateDate": "2015-06-16T02:35:47+08:00"
+	},
+	{
+		"id": 1800989,
+		"name": "pvt.services.us-south.bluemix.net",
+		"serial": 2016080303,
+		"updateDate": "2016-08-02T05:14:27+08:00"
+	},
+	{
+		"id": 1831180,
+		"name": "services.au-syd.bluemix.net",
+		"serial": 2016080905,
+		"updateDate": "2016-08-10T12:58:35+08:00"
+	},
+	{
+		"id": 1665181,
+		"name": "services.dal.bluemix.net",
+		"serial": 2016080904,
+		"updateDate": "2016-08-10T03:04:30+08:00"
+	},
+	{
+		"id": 1740168,
+		"name": "services.eu-gb.bluemix.net",
+		"serial": 2016080304,
+		"updateDate": "2016-08-04T02:02:03+08:00"
+	},
+	{
+		"id": 1831181,
+		"name": "services.stage1.au-syd.bluemix.net",
+		"serial": 2015091002,
+		"updateDate": "2015-09-11T06:10:44+08:00"
+	},
+	{
+		"id": 1857209,
+		"name": "services.stage1.eu-gb.bluemix.net",
+		"serial": 2016062200,
+		"updateDate": "2016-06-23T05:25:41+08:00"
+	},
+	{
+		"id": 1857208,
+		"name": "services.stage1.us-south.bluemix.net",
+		"serial": 2016062200,
+		"updateDate": "2016-06-23T09:56:48+08:00"
+	},
+	{
+		"id": 1739376,
+		"name": "services.tor.bluemix.net",
+		"serial": 2015041911,
+		"updateDate": "2015-04-20T11:22:35+08:00"
+	},
+	{
+		"id": 1819549,
+		"name": "services.us-south.bluemix.net",
+		"serial": 2016071400,
+		"updateDate": "2016-07-15T09:49:14+08:00"
+	},
+	{
+		"id": 1778007,
+		"name": "test.mql.services.dal.bluemix.net",
+		"serial": 2015030402,
+		"updateDate": "2015-03-05T01:27:56+08:00"
+	},
+	{
+		"id": 1939932,
+		"name": "zzc.test.domain.net",
+		"serial": 2016080903,
+		"updateDate": "2016-08-10T12:36:36+08:00"
+	}
+]

--- a/test_helpers/test_helpers.go
+++ b/test_helpers/test_helpers.go
@@ -698,7 +698,7 @@ func WaitForDeletedDnsDomainToNoLongerBePresent(dnsDomainId int) {
 	fmt.Printf("----> waiting for deleted dns domain to no longer be present\n")
 	Eventually(func() bool {
 		dnsDomain, err := dnsDomainService.GetObject(dnsDomainId)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).To(HaveOccurred())
 
 		if dnsDomain.Id == dnsDomainId {
 			return false


### PR DESCRIPTION
- rename method GetDnsDomains() to GetDomains()
- add missing GetDomains() in interface SoftLayer_Account_Service
- add faked fixture and real unit/integration test
- bug fix: test_helpers shoudl expect an error when querying an already deleted
  domain

(DCO 1.1 Signed-off-by: Wei Huang <hweicdl@cn.ibm.com>)