### PR TITLE
Workaround to simply change the defualt value from 1 to 3

### DIFF
--- a/client/http_client.go
+++ b/client/http_client.go
@@ -174,7 +174,7 @@ func (slc *HttpClient) makeHttpRequest(url string, requestType string, requestBo
 	}
 	SL_API_RETRY_COUNT, err := strconv.Atoi(os.Getenv("SL_API_RETRY_COUNT"))
 	if err != nil || SL_API_RETRY_COUNT == 0 {
-		SL_API_RETRY_COUNT = 1
+		SL_API_RETRY_COUNT = 3
 	}
 
 	for i := 1; i <= SL_API_RETRY_COUNT; i++ {


### PR DESCRIPTION
We found eCPI can't retrieve the value of environment variables as expected, and I confirmed that ENV is cleaned when BOSH invokes eCPI, so making this change as a quick workaround.