### PR TITLE
Fix the problem where request body is lost in retry

### DIFF
--- a/client/http_client.go
+++ b/client/http_client.go
@@ -156,7 +156,7 @@ func (slc *HttpClient) scheme() string {
 func (slc *HttpClient) makeHttpRequest(url string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error) {
 	var (
 		resp *http.Response
-		bs []byte
+		bs   []byte
 	)
 	body, _ := ioutil.ReadAll(requestBody)
 

--- a/client/http_client.go
+++ b/client/http_client.go
@@ -154,11 +154,13 @@ func (slc *HttpClient) scheme() string {
 }
 
 func (slc *HttpClient) makeHttpRequest(url string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error) {
-	var (
-		resp *http.Response
-		bs   []byte
-	)
-	body, _ := ioutil.ReadAll(requestBody)
+	var resp *http.Response
+	var bs []byte
+
+	body, err := ioutil.ReadAll(requestBody)
+	if err != nil {
+		return nil, 520, err
+	}
 
 	SL_API_WAIT_TIME, err := strconv.Atoi(os.Getenv("SL_API_WAIT_TIME"))
 	if err != nil || SL_API_WAIT_TIME == 0 {
@@ -187,10 +189,6 @@ func (slc *HttpClient) makeHttpRequest(url string, requestType string, requestBo
 		resp, err = slc.HTTPClient.Do(req)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[softlayer-go] Error: %s, retrying %d time(s)\n", err.Error(), i)
-
-			b, _ := ioutil.ReadAll(req.Body)
-			fmt.Fprintf(os.Stderr, "[softlayer-go] request body is : %s", b)
-
 			if !strings.Contains(err.Error(), "i/o timeout") && !strings.Contains(err.Error(), "connection refused") && !strings.Contains(err.Error(), "connection reset by peer") || i >= SL_API_RETRY_COUNT {
 				return nil, 520, err
 			}

--- a/client/http_client.go
+++ b/client/http_client.go
@@ -154,21 +154,12 @@ func (slc *HttpClient) scheme() string {
 }
 
 func (slc *HttpClient) makeHttpRequest(url string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error) {
-	req, err := http.NewRequest(requestType, url, requestBody)
-	if err != nil {
-		return nil, 0, err
-	}
+	var (
+		resp *http.Response
+		bs []byte
+	)
+	body, _ := ioutil.ReadAll(requestBody)
 
-	bs, err := httputil.DumpRequest(req, true)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	if !slc.nonVerbose {
-		fmt.Fprintf(os.Stderr, "\n---\n[softlayer-go] Request:\n%s\n", hideCredentials(string(bs)))
-	}
-
-	var resp *http.Response
 	SL_API_WAIT_TIME, err := strconv.Atoi(os.Getenv("SL_API_WAIT_TIME"))
 	if err != nil || SL_API_WAIT_TIME == 0 {
 		SL_API_WAIT_TIME = 1
@@ -179,10 +170,28 @@ func (slc *HttpClient) makeHttpRequest(url string, requestType string, requestBo
 	}
 
 	for i := 1; i <= SL_API_RETRY_COUNT; i++ {
+		req, err := http.NewRequest(requestType, url, bytes.NewReader(body))
+		if err != nil {
+			return nil, 0, err
+		}
+
+		bs, err = httputil.DumpRequest(req, true)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if !slc.nonVerbose {
+			fmt.Fprintf(os.Stderr, "\n---\n[softlayer-go] Request:\n%s\n", hideCredentials(string(bs)))
+		}
+
 		resp, err = slc.HTTPClient.Do(req)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[softlayer-go] Error: %s, retrying %d time(s)\n", err.Error(), i)
-			if !strings.Contains(err.Error(), "i/o timeout") && !strings.Contains(err.Error(), "connection refused") || i >= SL_API_RETRY_COUNT {
+
+			b, _ := ioutil.ReadAll(req.Body)
+			fmt.Fprintf(os.Stderr, "[softlayer-go] request body is : %s", b)
+
+			if !strings.Contains(err.Error(), "i/o timeout") && !strings.Contains(err.Error(), "connection refused") && !strings.Contains(err.Error(), "connection reset by peer") || i >= SL_API_RETRY_COUNT {
 				return nil, 520, err
 			}
 		} else {

--- a/client/http_client_test.go
+++ b/client/http_client_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/onsi/gomega/ghttp"
 
 	slclient "github.com/maximilien/softlayer-go/client"
+	"io/ioutil"
 )
 
 var _ = Describe("A HTTP Client", func() {
@@ -81,10 +82,19 @@ var _ = Describe("A HTTP Client", func() {
 			}
 		})
 
-		It("send a request to an instable HTTP server", func() {
+		It("send a GET request to an instable HTTP server", func() {
 			go delayStartHTTPServer(4, port)
 			_, _, err := client.DoRawHttpRequest("timeoutTest", "GET", bytes.NewBufferString("test"))
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("send a POST request to an instable HTTP server", func() {
+			body := "post-request-test"
+			go delayStartHTTPServer(4, port)
+			rep, _, err := client.DoRawHttpRequest("postRequest", "POST", bytes.NewBufferString(body))
+			Expect(err).ToNot(HaveOccurred())
+			Ω(rep).Should(ContainSubstring(body))
+
 		})
 	})
 })
@@ -105,5 +115,6 @@ func delayStartHTTPServer(waitTime int, port int) error {
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "%s", r.URL.Path[1:])
+	b, _ := ioutil.ReadAll(r.Body)
+	fmt.Fprintf(w, "%s", string(b))
 }


### PR DESCRIPTION
Got a problem reported by SRE that there occurred the following error when CPI sent a POST request in 2nd retry:

```
173612:[softlayer-go] Error: Post https://<user>:<apikey>@api.service.softlayer.com/rest/v3/S
oftLayer_Product_Order/placeOrder.json: http: ContentLength=358 with Body length 0, retrying 2 time(s)
```

It's because the request body had been consumed by the 1st try, there is empty in 2nd try. I referenced the following post to fix the problem:

http://stackoverflow.com/questions/31337891/net-http-http-contentlength-222-with-body-length-0